### PR TITLE
fix(core): wrap process.on() listener bodies in withLogContext

### DIFF
--- a/apps/riven/lib/index.ts
+++ b/apps/riven/lib/index.ts
@@ -1,65 +1,79 @@
 import { randomUUID } from "node:crypto";
 import { setEnvironmentData } from "node:worker_threads";
 
-import { SessionID, withLogContext } from "./utilities/logger/log-context.ts";
+import {
+  type LogContext,
+  SessionID,
+  withLogContext,
+} from "./utilities/logger/log-context.ts";
 
 const sessionId = SessionID.parse(randomUUID());
 
 setEnvironmentData("riven.session.id", sessionId);
 
-await withLogContext(
-  {
-    "riven.log.source": "core",
-    "riven.session.id": sessionId,
-  },
-  async () => {
-    await import("./sentry.ts");
+const baseLogContext: LogContext = {
+  "riven.log.source": "core",
+  "riven.session.id": sessionId,
+};
 
-    const { createActor, waitFor } = await import("xstate");
+await withLogContext(baseLogContext, async () => {
+  await import("./sentry.ts");
 
-    const { rivenMachine } = await import("./state-machines/program/index.ts");
-    const { logger } = await import("./utilities/logger/logger.ts");
+  const { createActor, waitFor } = await import("xstate");
 
-    process.on("uncaughtException", (error) => {
+  const { rivenMachine } = await import("./state-machines/program/index.ts");
+  const { logger } = await import("./utilities/logger/logger.ts");
+
+  // Node fires `uncaughtException` and `unhandledRejection` listeners from
+  // a fresh execution context, not the AsyncLocalStorage scope of the
+  // registration site. Without an explicit `withLogContext` wrap here, the
+  // `logger.error(...)` calls below resolve no log context and trip the
+  // intentional throw in `getLogContext`, which masks the original error
+  // in `exceptions.log` and exits the process. Re-establish the same base
+  // context on each invocation so the logger can do its job.
+  process.on("uncaughtException", (error) => {
+    withLogContext(baseLogContext, () => {
       logger.error("Uncaught exception", { err: error });
 
       process.exit(1);
     });
+  });
 
-    process.on("unhandledRejection", (error) => {
+  process.on("unhandledRejection", (error) => {
+    withLogContext(baseLogContext, () => {
       logger.error("Uncaught rejection", { err: error });
     });
+  });
 
-    const actor = createActor(rivenMachine, {
-      input: {
-        sessionId,
-      },
-    });
+  const actor = createActor(rivenMachine, {
+    input: {
+      sessionId,
+    },
+  });
 
-    actor.start();
+  actor.start();
 
-    process.on("SIGINT", () => {
-      const { value } = actor.getSnapshot();
-      const stoppableStates: (typeof value)[] = ["Running", "Bootstrapping"];
-
-      if (stoppableStates.includes(value)) {
-        actor.send({ type: "riven.core.shutdown" });
-      }
-    });
-
-    await waitFor(
-      actor,
-      (state) => state.matches("Exited") || state.matches("Errored"),
-    );
-
+  process.on("SIGINT", () => {
     const { value } = actor.getSnapshot();
+    const stoppableStates: (typeof value)[] = ["Running", "Bootstrapping"];
 
-    if (value === "Errored") {
-      process.exit(1);
+    if (stoppableStates.includes(value)) {
+      actor.send({ type: "riven.core.shutdown" });
     }
+  });
 
-    logger.info("Riven has shut down");
+  await waitFor(
+    actor,
+    (state) => state.matches("Exited") || state.matches("Errored"),
+  );
 
-    process.exit(0);
-  },
-);
+  const { value } = actor.getSnapshot();
+
+  if (value === "Errored") {
+    process.exit(1);
+  }
+
+  logger.info("Riven has shut down");
+
+  process.exit(0);
+});


### PR DESCRIPTION
> [!NOTE]
> Force-pushed to replace the previous approach. Previous version of this PR made `getLogContext` return `{}` outside a scope. @joemckie correctly pushed back: that throw is a deliberate tripwire, not a bug. This rewrite keeps the tripwire and fixes the actual contextless caller.

## Problem

`ghcr.io/rivenmedia/riven-ts:main` boot-loops on aarch64 hosts with the secondary error:

```
Error: No log context available
    at getLogContext (file:///app/dist/program/lib/utilities/logger/log-context.js:21:15)
    at Format.transform (file:///app/dist/program/lib/utilities/logger/formatters/sentry-meta.format.js:13:12)
```

The original error (an `ERR_DLOPEN_FAILED` for `fuse.node`, see #87) is captured in `exceptions.log` but never reaches stdout, because the `uncaughtException` handler trips a secondary throw before winston can flush.

## Root cause

`apps/riven/lib/index.ts` wraps the program in `withLogContext` and registers listeners on `process`:

```ts
process.on("uncaughtException", (error) => {
  logger.error("Uncaught exception", { err: error });
  process.exit(1);
});
process.on("unhandledRejection", (error) => {
  logger.error("Uncaught rejection", { err: error });
});
```

Node invokes `uncaughtException` and `unhandledRejection` listeners in a **fresh execution context**, not the AsyncLocalStorage scope that was active at registration time. So the `logger.error(...)` call inside each listener resolves no scope, the Sentry meta winston formatter calls `getLogContext()`, and the deliberate throw fires. The throw is correct: a contextless log emission is a real bug. The bug here is that the listener bodies escape the context.

## Fix

Hoist the base log context into a local `baseLogContext: LogContext` and re-establish it inside each listener body via `withLogContext(baseLogContext, ...)`. The throw in `getLogContext` is preserved so future contextless callers still get caught.

```ts
const baseLogContext: LogContext = {
  "riven.log.source": "core",
  "riven.session.id": sessionId,
};

await withLogContext(baseLogContext, async () => {
  // ...
  process.on("uncaughtException", (error) => {
    withLogContext(baseLogContext, () => {
      logger.error("Uncaught exception", { err: error });
      process.exit(1);
    });
  });

  process.on("unhandledRejection", (error) => {
    withLogContext(baseLogContext, () => {
      logger.error("Uncaught rejection", { err: error });
    });
  });
  // ...
});
```

`SIGINT` doesn't need this wrap because it doesn't call `logger.*` directly; it only sends an event to the actor.

## Verification

Locally reproduced the original boot loop by triggering an early `uncaughtException` (the `fuse.node` arm64 issue from #87 was the natural trigger). Before this change: secondary throw, no useful stdout, `exceptions.log` grows. After this change: the original error reaches stdout via the wrapped logger, then the process exits cleanly with the intended exit(1).

Test plan suggestion: a focused unit test that registers a sentinel `process.on("uncaughtException", ...)` listener inside a scope, removes the scope, throws, and asserts the listener's `logger.error` succeeded without `getLogContext` throwing. Happy to add this if you'd like (the apps/riven vitest setup is heavy enough that I held off).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging reliability for uncaught exceptions and unhandled promise rejections, ensuring proper error context in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->