### PR TITLE
chore: gitignore docker-compose.override.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ plex
 *.bundled_*.mjs
 docker-data
 *.graphql
+
+# Local-only Compose overrides (auto-loaded by docker compose)
+docker-compose.override.yaml
+docker-compose.override.yml


### PR DESCRIPTION
`docker-compose.override.yaml` (and the `.yml` variant) are auto-loaded by `docker compose` when present. The canonical Compose convention is to treat them as local-only files for per-developer or per-environment tweaks: pinning a specific image tag, swapping a runtime when GPU/FUSE/etc. isn't available locally, bind-mounting a build artifact for testing, and so on.

Today, after a developer runs `docker compose` once with a local override, the file shows up as untracked in `git status` and trips on `git add .`. The fix is one .gitignore entry.

Reference: <https://docs.docker.com/compose/multiple-compose-files/merge/>

(Came up while testing the riven-ts dev stack on macOS. I needed an override to swap the unbuilt `:latest` to `:main`, drop nvidia GPU on Plex, and remove rshared bind propagation that Docker Desktop doesn't support.)