### PR TITLE
fix(compose): pin riven service to :main tag (default :latest is unpublished)

### DIFF
--- a/apps/riven/docker-compose.yaml
+++ b/apps/riven/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   riven:
     container_name: riven
-    image: ghcr.io/rivenmedia/riven-ts
+    image: ghcr.io/rivenmedia/riven-ts:main
     restart: unless-stopped
     tty: true
     cap_add:


### PR DESCRIPTION
`apps/riven/docker-compose.yaml` referenced `ghcr.io/rivenmedia/riven-ts` with no tag, which Docker resolves to `:latest`. The publish workflow (`build-docker-images.yaml`) emits these tags for pushes to `main`:

- `:main`                  (`type=ref,event=branch`)
- `:sha-<short>`           (`type=sha`)
- `:pr-<number>`           (`type=ref,event=pr`, on PRs only)
- `:{{version}}` etc.      (`type=semver`, on releases - none yet)

There is no `:latest` today, so `docker compose pull` on a fresh checkout fails:

```
Image ghcr.io/rivenmedia/riven-ts:main Pulled
Image ghcr.io/rivenmedia/riven-ts Error
  failed to resolve reference "ghcr.io/rivenmedia/riven-ts:latest": not found
```

This PR pins the compose to `:main`, which is the rolling dev tag and matches the apparent intent of the dev compose stack.

## Alternative

Add `type=raw,value=latest,enable={{is_default_branch}}` (or `flavor: latest=auto`) to the metadata-action so `:latest` follows main (and later, the highest semver release once releases are cut). Out of scope for this PR but worth doing as a follow-up if you'd prefer the convention-driven `:latest` over the explicit `:main` pin.