### PR TITLE
fix(mdblist): imdb_id nullability

### DIFF
--- a/packages/plugin-mdblist/lib/datasource/mdblist.datasource.ts
+++ b/packages/plugin-mdblist/lib/datasource/mdblist.datasource.ts
@@ -109,7 +109,7 @@ export class MdblistAPI extends BaseDataSource<MdbListSettings> {
 
               if (!this.#seenShowIds.has(item.id)) {
                 showIdsMap.set(item.id, {
-                  imdbId: item.imdb_id || undefined,
+                  imdbId: item.imdb_id ?? undefined,
                   tvdbId: item.tvdb_id?.toString(),
                 });
               }

--- a/packages/plugin-mdblist/lib/datasource/mdblist.datasource.ts
+++ b/packages/plugin-mdblist/lib/datasource/mdblist.datasource.ts
@@ -109,7 +109,7 @@ export class MdblistAPI extends BaseDataSource<MdbListSettings> {
 
               if (!this.#seenShowIds.has(item.id)) {
                 showIdsMap.set(item.id, {
-                  imdbId: item.imdb_id,
+                  imdbId: item.imdb_id || undefined,
                   tvdbId: item.tvdb_id?.toString(),
                 });
               }

--- a/packages/plugin-mdblist/openapi-schema.json
+++ b/packages/plugin-mdblist/openapi-schema.json
@@ -1289,7 +1289,8 @@
                             "type": "string"
                           },
                           "imdb_id": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                           },
                           "tvdb_id": {
                             "nullable": true
@@ -1912,7 +1913,8 @@
                             "type": "string"
                           },
                           "imdb_id": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                           },
                           "tvdb_id": {
                             "nullable": true
@@ -1986,7 +1988,8 @@
                             "type": "string"
                           },
                           "imdb_id": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                           },
                           "tvdb_id": {
                             "type": "number",
@@ -4914,7 +4917,8 @@
                             "type": "string"
                           },
                           "imdb_id": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                           },
                           "tvdb_id": {
                             "nullable": true
@@ -10228,7 +10232,8 @@
                             "type": "string"
                           },
                           "imdb_id": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                           },
                           "tvdb_id": {
                             "nullable": true
@@ -10288,7 +10293,8 @@
                             "type": "string"
                           },
                           "imdb_id": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                           },
                           "tvdb_id": {
                             "type": "number",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API schema to reflect that the `imdb_id` field can now be null in movie and show list item responses across all relevant endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->