### PR TITLE
chore(core): send all log levels to ECS file

### DIFF
--- a/apps/riven/lib/utilities/logger/logger.ts
+++ b/apps/riven/lib/utilities/logger/logger.ts
@@ -45,6 +45,7 @@ if (settings.loggingEnabled) {
       maxFiles: 5,
       format: ecsFileFormat,
       zippedArchive: true,
+      level: "silly", // Send ALL logs to ECS, regardless of log level config
     }),
   );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ECS JSON log files now capture all log levels when logging is enabled, ensuring comprehensive logging regardless of the global log level configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->