### PR TITLE
fix(verify): skip knip-reporter step on PRs from forks

### DIFF
--- a/.github/actions/post-verify/action.yaml
+++ b/.github/actions/post-verify/action.yaml
@@ -14,8 +14,16 @@ runs:
       if: ${{ inputs.task == 'test' }}
       uses: ./.github/actions/generate-coverage-report
 
+    # codex-/knip-reporter calls GitHub's create-check API, which requires
+    # `checks: write` on the GITHUB_TOKEN. PRs from forks always get a
+    # read-only token regardless of what the workflow declares, so the
+    # action errors with "Failed to create check" and that propagates up
+    # to fail the verify workflow (and gates build-docker-images). Skip
+    # the reporter on fork PRs; same-repo PRs and pushes to main retain
+    # the full reporting behavior.
     - name: Report Knip results in PR
-      if: ${{ inputs.task == '//#knip:ci:production' }}
+      if: ${{ inputs.task == '//#knip:ci:production' &&
+        !github.event.pull_request.head.repo.fork }}
       uses: codex-/knip-reporter@v3
       with:
         command_script_name: knip:ci:production


### PR DESCRIPTION
## Summary

`codex-/knip-reporter@v3` (called from `.github/actions/post-verify/action.yaml`) calls GitHub's create-check API, which requires `checks: write` on the `GITHUB_TOKEN`. PRs from forks always get a read-only token regardless of what the workflow's `permissions:` block declares (GitHub security policy), so the action errors with `Failed to create check`. That failure propagates up through the composite action, fails the `verify` workflow, and gates `build-docker-images` from running.

Net effect: since #113 merged, every fork PR's CI has been failing fast at the same step, even on otherwise-clean PRs. Pattern visible on #87's recent runs (`25644733945`, `25691961018`, `25692233004`, `25694125695`).

## Fix

Add an `if:` condition to skip the reporter step when the PR head is in a fork. Same-repo PRs and pushes to `main` retain the full reporting behavior. Fork contributors lose the in-PR Knip summary check, but they were never seeing it anyway (the action errors on every fork PR); the underlying `knip:ci:production` task still runs and still fails the build on real Knip violations.

`!github.event.pull_request.head.repo.fork` evaluates to `true` on pushes too (no PR context, `github.event.pull_request` is null), so push events to `main` are unaffected.

## Test plan

- [ ] On a fork PR: `verify` workflow completes without the `Failed to create check` error; `build-docker-images` runs to completion (or fails on its own merits).
- [ ] On a same-repo PR or push to main: `knip-reporter` still posts the check as it does today.
- [ ] Real Knip violations still fail the build via the underlying `//#knip:ci:production` turbo task (the reporter is downstream of the actual check).