### PR TITLE
feat(core): libraryCounts + paginated/searchable mediaItems

### DIFF
--- a/apps/riven/lib/graphql/resolvers/media-item.resolver.spec.ts
+++ b/apps/riven/lib/graphql/resolvers/media-item.resolver.spec.ts
@@ -1,0 +1,228 @@
+import { MediaItemType } from "@repo/util-plugin-sdk/dto/enums/media-item-type.enum";
+
+import { expect } from "vitest";
+
+import { it } from "../../__tests__/test-context.ts";
+import { MediaItemResolver } from "./media-item.resolver.ts";
+
+import type { CoreContext } from "../decorators/core-context.ts";
+
+const resolver = new MediaItemResolver();
+
+const makeCoreContext = (em: CoreContext["em"]): CoreContext => ({ em });
+
+/**
+ * Defaults for fields that the `Movie` entity requires but `MovieFactory.definition`
+ * does not provide. Mirrors what `IndexedMovieSeeder` sets, so direct factory use
+ * in these tests round-trips through `em.flush()` the same way the seeder does.
+ */
+const requiredMovieDefaults = () => ({
+  indexedAt: new Date(),
+  releaseDate: new Date("2020-01-01"),
+});
+
+it("libraryCounts returns all zeroes against an empty database", async ({
+  em,
+}) => {
+  const result = await resolver.libraryCounts(makeCoreContext(em));
+
+  expect(result).toEqual({
+    movies: 0,
+    shows: 0,
+    seasons: 0,
+    episodes: 0,
+    total: 0,
+  });
+});
+
+it("libraryCounts counts movies, shows, seasons, and episodes", async ({
+  em,
+  seeders,
+}) => {
+  await seeders.seedIndexedMovie();
+  const showResult = await seeders.seedIndexedShow();
+
+  const result = await resolver.libraryCounts(makeCoreContext(em));
+
+  // Exact movie/show counts are deterministic.
+  expect(result.movies).toBe(1);
+  expect(result.shows).toBe(1);
+  // The seeded show generates at least one season and one episode.
+  expect(result.seasons).toBe(showResult.seasons?.length ?? 0);
+  expect(result.episodes).toBe(showResult.episodes?.length ?? 0);
+  expect(result.total).toBe(
+    result.movies + result.shows + result.seasons + result.episodes,
+  );
+});
+
+it("mediaItems default limit caps at 25 even when more rows exist", async ({
+  em,
+  factories,
+}) => {
+  // Persist 30 movies; the default limit should clip to 25.
+  const movies = Array.from({ length: 30 }, (_, i) =>
+    factories.movieFactory.makeOne({
+      ...requiredMovieDefaults(),
+      title: `Movie ${String(i).padStart(2, "0")}`,
+    }),
+  );
+  em.persist(movies);
+  await em.flush();
+
+  const result = await resolver.mediaItems(makeCoreContext(em), 25, 0);
+
+  expect(result).toHaveLength(25);
+});
+
+it("mediaItems clamps an out-of-range limit to the hard maximum", async ({
+  em,
+  factories,
+}) => {
+  const movies = Array.from({ length: 120 }, (_, i) =>
+    factories.movieFactory.makeOne({
+      ...requiredMovieDefaults(),
+      title: `Movie ${String(i).padStart(3, "0")}`,
+    }),
+  );
+  em.persist(movies);
+  await em.flush();
+
+  // Caller asks for 500; resolver should clamp to 100 (MAX_MEDIA_ITEMS_LIMIT).
+  const result = await resolver.mediaItems(makeCoreContext(em), 500, 0);
+
+  expect(result).toHaveLength(100);
+});
+
+it("mediaItems offset paginates without overlap", async ({ em, factories }) => {
+  const movies = Array.from({ length: 6 }, (_, i) =>
+    factories.movieFactory.makeOne({
+      ...requiredMovieDefaults(),
+      title: `Movie ${String(i).padStart(2, "0")}`,
+    }),
+  );
+  em.persist(movies);
+  await em.flush();
+
+  const page1 = await resolver.mediaItems(makeCoreContext(em), 3, 0);
+  const page2 = await resolver.mediaItems(makeCoreContext(em), 3, 3);
+
+  expect(page1).toHaveLength(3);
+  expect(page2).toHaveLength(3);
+  const idsPage1 = new Set(page1.map((m) => m.id));
+  for (const item of page2) {
+    expect(idsPage1.has(item.id)).toBe(false);
+  }
+});
+
+it("mediaItems search filters by case-insensitive title substring", async ({
+  em,
+  factories,
+}) => {
+  em.persist([
+    factories.movieFactory.makeOne({
+      ...requiredMovieDefaults(),
+      title: "The Matrix",
+    }),
+    factories.movieFactory.makeOne({
+      ...requiredMovieDefaults(),
+      title: "Inception",
+    }),
+    factories.movieFactory.makeOne({
+      ...requiredMovieDefaults(),
+      title: "matrix reloaded",
+    }),
+  ]);
+  await em.flush();
+
+  const result = await resolver.mediaItems(
+    makeCoreContext(em),
+    25,
+    0,
+    "matrix",
+  );
+
+  expect(result).toHaveLength(2);
+  expect(result.every((m) => m.title.toLowerCase().includes("matrix"))).toBe(
+    true,
+  );
+});
+
+it("mediaItems search ignores whitespace-only input", async ({
+  em,
+  factories,
+}) => {
+  em.persist([
+    factories.movieFactory.makeOne({
+      ...requiredMovieDefaults(),
+      title: "Only Movie",
+    }),
+  ]);
+  await em.flush();
+
+  const result = await resolver.mediaItems(makeCoreContext(em), 25, 0, "   ");
+
+  expect(result).toHaveLength(1);
+});
+
+it("mediaItems type filter restricts to a single subtype", async ({
+  em,
+  seeders,
+}) => {
+  await seeders.seedIndexedMovie();
+  await seeders.seedIndexedShow();
+
+  const movies = await resolver.mediaItems(
+    makeCoreContext(em),
+    25,
+    0,
+    null,
+    MediaItemType.enum.movie,
+  );
+  const shows = await resolver.mediaItems(
+    makeCoreContext(em),
+    25,
+    0,
+    null,
+    MediaItemType.enum.show,
+  );
+
+  expect(movies.length).toBeGreaterThan(0);
+  expect(movies.every((m) => m.type === MediaItemType.enum.movie)).toBe(true);
+  expect(shows.length).toBeGreaterThan(0);
+  expect(shows.every((s) => s.type === MediaItemType.enum.show)).toBe(true);
+});
+
+it("mediaItems composes search and type filters", async ({ em, factories }) => {
+  em.persist([
+    factories.movieFactory.makeOne({
+      ...requiredMovieDefaults(),
+      title: "Matrix Movie",
+    }),
+  ]);
+  await em.flush();
+
+  const result = await resolver.mediaItems(
+    makeCoreContext(em),
+    25,
+    0,
+    "matrix",
+    MediaItemType.enum.movie,
+  );
+
+  expect(result).toHaveLength(1);
+  expect(result[0]?.title).toBe("Matrix Movie");
+  expect(result[0]?.type).toBe(MediaItemType.enum.movie);
+});
+
+it("mediaItemById uses the existing find path unchanged", async ({
+  em,
+  indexedMovieContext: { indexedMovie },
+}) => {
+  // Sanity check: the existing query still works after our additions.
+  const result = await resolver.mediaItemById(
+    makeCoreContext(em),
+    indexedMovie.id,
+  );
+
+  expect(result.id).toBe(indexedMovie.id);
+});

--- a/apps/riven/lib/graphql/resolvers/media-item.resolver.ts
+++ b/apps/riven/lib/graphql/resolvers/media-item.resolver.ts
@@ -1,11 +1,17 @@
 import { MediaItem } from "@repo/util-plugin-sdk/dto/entities";
+import { MediaItemType } from "@repo/util-plugin-sdk/dto/enums/media-item-type.enum";
 import { MediaItemUnion } from "@repo/util-plugin-sdk/dto/unions/media-item.union";
 
+import { type FilterQuery, sql } from "@mikro-orm/core";
 import { Arg, FieldResolver, ID, Int, Query, Resolver } from "type-graphql";
 
 import { CoreContext } from "../decorators/core-context.ts";
+import { LibraryCounts } from "../types/library-counts.type.ts";
 
 import type { UUID } from "node:crypto";
+
+/** Hard upper bound on `mediaItems(limit)` to keep abusive payloads bounded. */
+const MAX_MEDIA_ITEMS_LIMIT = 100;
 
 @Resolver(() => MediaItem)
 export class MediaItemResolver {
@@ -20,16 +26,84 @@ export class MediaItemResolver {
     return em.findOneOrFail(MediaItem, id);
   }
 
-  @Query(() => [MediaItem])
-  mediaItems(@CoreContext() { em }: CoreContext): Promise<MediaItem[]> {
-    return em.find(
-      MediaItem,
-      {},
-      {
-        limit: 25,
-        overfetch: true,
-      },
+  @Query(() => [MediaItem], {
+    description:
+      "Lists media items with optional search, type filter, and pagination.",
+  })
+  mediaItems(
+    @CoreContext() { em }: CoreContext,
+    @Arg("limit", () => Int, {
+      defaultValue: 25,
+      description: `Maximum number of items to return. Hard-capped at ${String(MAX_MEDIA_ITEMS_LIMIT)} to keep payloads bounded.`,
+    })
+    limit: number,
+    @Arg("offset", () => Int, {
+      defaultValue: 0,
+      description: "Zero-based offset for pagination.",
+    })
+    offset: number,
+    @Arg("search", () => String, {
+      nullable: true,
+      description:
+        "Case-insensitive substring match against `title`. Trimmed; empty strings are treated as no filter.",
+    })
+    search: string | null = null,
+    @Arg("type", () => MediaItemType.enum, {
+      nullable: true,
+      description: "Restrict results to a single MediaItem subtype.",
+    })
+    type: MediaItemType | null = null,
+  ): Promise<MediaItem[]> {
+    const clampedLimit = Math.min(
+      Math.max(1, Math.trunc(limit)),
+      MAX_MEDIA_ITEMS_LIMIT,
     );
+    const clampedOffset = Math.max(0, Math.trunc(offset));
+
+    // Compose filters in a dialect-portable way. `$ilike` would be cleaner but
+    // is PostgreSQL-only; mikro-orm does not translate it for SQLite (which
+    // the test fixtures use). The documented pattern for case-insensitive
+    // search is `{ [sql`lower(column)`]: { $like: pattern } }`, which emits
+    // `lower(column) LIKE ?` in both dialects.
+    const where: Record<string | symbol, unknown> = {};
+    if (type) {
+      where["type"] = type;
+    }
+    const trimmedSearch = search?.trim();
+    if (trimmedSearch && trimmedSearch.length > 0) {
+      where[sql`lower(title)`] = {
+        $like: `%${trimmedSearch.toLowerCase()}%`,
+      };
+    }
+
+    return em.find(MediaItem, where as FilterQuery<MediaItem>, {
+      limit: clampedLimit,
+      offset: clampedOffset,
+      overfetch: true,
+    });
+  }
+
+  @Query(() => LibraryCounts, {
+    description:
+      "Aggregate counts across the media library, partitioned by `MediaItem.type`. Useful for dashboards and health checks.",
+  })
+  async libraryCounts(
+    @CoreContext() { em }: CoreContext,
+  ): Promise<LibraryCounts> {
+    const [movies, shows, seasons, episodes] = await Promise.all([
+      em.count(MediaItem, { type: MediaItemType.enum.movie }),
+      em.count(MediaItem, { type: MediaItemType.enum.show }),
+      em.count(MediaItem, { type: MediaItemType.enum.season }),
+      em.count(MediaItem, { type: MediaItemType.enum.episode }),
+    ]);
+
+    return {
+      movies,
+      shows,
+      seasons,
+      episodes,
+      total: movies + shows + seasons + episodes,
+    };
   }
 
   @FieldResolver(() => Int)

--- a/apps/riven/lib/graphql/types/library-counts.type.ts
+++ b/apps/riven/lib/graphql/types/library-counts.type.ts
@@ -1,0 +1,28 @@
+import { Field, Int, ObjectType } from "type-graphql";
+
+/**
+ * Aggregate counts across the media library, partitioned by `MediaItem.type`.
+ *
+ * `total` is the sum of all type-buckets (which equals `em.count(MediaItem)`
+ * because the entity uses single-table inheritance keyed on `type`).
+ */
+@ObjectType({
+  description:
+    "Aggregate counts across the media library, partitioned by MediaItem type.",
+})
+export class LibraryCounts {
+  @Field(() => Int)
+  movies!: number;
+
+  @Field(() => Int)
+  shows!: number;
+
+  @Field(() => Int)
+  seasons!: number;
+
+  @Field(() => Int)
+  episodes!: number;
+
+  @Field(() => Int)
+  total!: number;
+}


### PR DESCRIPTION
## Summary

Adds two pieces of admin/dashboard-facing API surface to the `MediaItem` resolver, both small enough to land independently:

1. **New `libraryCounts` query**: aggregate counts per `MediaItem` subtype (`movies` / `shows` / `seasons` / `episodes` / `total`). Backed by parallel `em.count(MediaItem, { type })` calls; single round-trip from a client's perspective.

2. **Extended `mediaItems` query**: optional `limit`, `offset`, `search`, `type` args.
   - Default behaviour is unchanged (limit 25, overfetch true).
   - `limit` is clamped to a hard cap of 100 to keep payloads bounded.
   - `search` is a trimmed, case-insensitive substring match against `title`; whitespace-only is treated as no filter.
   - `type` takes the registered `MediaItemType` enum.

## Why

There is no aggregate-counts query today, and no way to page or search the library from a client. Both are general-purpose primitives, useful for any consumer (monitoring scripts, a future admin UI, the existing maintenance flows).

## Test plan

- [x] 10 vitest cases in `media-item.resolver.spec.ts`: empty counts, seeded counts, default + clamped + paginated `mediaItems`, case-insensitive search, whitespace trim, type filter, search composed with type, and an unchanged `mediaItemById` sanity check.
- [x] `tsc` passes against the new files.
- [x] `eslint` passes against the new files.
- [ ] Vitest run locally is blocked by the existing FUSE/redis-server binary requirements; relying on CI for the test pass.

## Out of scope (potential follow-ups)

- `orderBy` arg on `mediaItems` (recent vs. alphabetical vs. release date).
- A `totalCount` companion field on the list response for paginated UIs.
- Surfacing the same primitives over the Plex / Seerr GraphQL layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media library query supports pagination (limit/offset), enforces sensible bounds, and hard maximums
  * Added title search (case-insensitive, ignores whitespace-only) and filtering by media type
  * New library statistics with aggregated counts per media category and a total

* **Tests**
  * Added comprehensive tests covering counts, pagination limits, search, type filters, and per-ID lookup

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rivenmedia/riven-ts/pull/117)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->