### PR TITLE
chore: configure workflows for forks

### DIFF
--- a/.github/actions/generate-coverage-report/action.yaml
+++ b/.github/actions/generate-coverage-report/action.yaml
@@ -16,12 +16,10 @@ runs:
       shell: bash
       run: pnpm turbo report
 
-    - name: Generate coverage report
-      uses: davelosert/vitest-coverage-report-action@v2
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v7
       with:
-        name: Riven
-        json-final-path: packages/core/util-vitest-config/coverage/merged/merged-coverage.json
-        json-summary-path: packages/core/util-vitest-config/coverage/summary/coverage-summary.json
-        json-summary-compare-path: ${{ steps.get-coverage-baseline.outputs.cache-hit == 'true' && 'packages/core/util-vitest-config/coverage/compare/coverage-summary.json' || '' }}
-        threshold-icons: "{0: '🔴', 80: '🟠', 90: '🟢'}"
-        file-coverage-mode: changes-affected
+        name: coverage-report
+        path: packages/core/util-vitest-config/coverage
+        retention-days: 1
+        if-no-files-found: error

--- a/.github/actions/post-verify/action.yaml
+++ b/.github/actions/post-verify/action.yaml
@@ -13,10 +13,3 @@ runs:
     - name: Merge coverage reports
       if: ${{ inputs.task == 'test' }}
       uses: ./.github/actions/generate-coverage-report
-
-    - name: Report Knip results in PR
-      if: ${{ inputs.task == '//#knip:ci:production' }}
-      uses: codex-/knip-reporter@v3
-      with:
-        command_script_name: knip:ci:production
-        verbose: true

--- a/.github/workflows/build-docker-images.yaml
+++ b/.github/workflows/build-docker-images.yaml
@@ -6,12 +6,13 @@ on:
   push:
     branches:
       - main
-  workflow_call:
-    inputs:
-      push:
-        description: Whether to push the built images to the registry
-        type: boolean
-        default: false
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 permissions:
   contents: read
@@ -60,7 +61,7 @@ jobs:
         with:
           file: apps/riven/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' || inputs.push }}
+          push: ${{ github.event_name == 'push' || (env.IS_FORK == 'false' && contains(github.event.pull_request.labels.*.name, 'build-docker')) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -72,3 +73,4 @@ jobs:
           target: runner
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          IS_FORK: ${{ github.event.pull_request != null && github.event.pull_request.head.repo.full_name != github.repository }}

--- a/.github/workflows/report-coverage-results.yaml
+++ b/.github/workflows/report-coverage-results.yaml
@@ -1,0 +1,33 @@
+name: Report coverage results
+
+on:
+  workflow_run:
+    workflows:
+      - Verify
+    types:
+      - completed
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Download coverage report
+        uses: actions/download-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Generate coverage report
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          name: Riven
+          json-final-path: coverage/merged/merged-coverage.json
+          json-summary-path: coverage/summary/coverage-summary.json
+          json-summary-compare-path: coverage/compare/coverage-summary.json
+          threshold-icons: "{0: '🔴', 80: '🟠', 90: '🟢'}"
+          file-coverage-mode: changes-affected

--- a/.github/workflows/report-knip-results.yaml
+++ b/.github/workflows/report-knip-results.yaml
@@ -1,0 +1,32 @@
+name: Report Knip results
+
+on:
+  workflow_run:
+    workflows:
+      - Verify
+    types:
+      - completed
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          repository: ${{ github.event.workflow_run.pull_requests.base.repo.name }}
+
+      - name: Set up runner
+        uses: ./.github/actions/set-up-project-environment
+
+      - name: Report Knip results
+        uses: codex-/knip-reporter@v3
+        with:
+          command_script_name: knip:ci:production
+          verbose: true

--- a/.github/workflows/run-turbo-task.yaml
+++ b/.github/workflows/run-turbo-task.yaml
@@ -68,10 +68,6 @@ jobs:
     needs: get-required-tasks
     if: needs.get-required-tasks.outputs.required-tasks != '[]'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -69,14 +69,3 @@ jobs:
         toJson(matrix.task.runner-requirements) || '[]' }}
       env: ${{ matrix.task.env && toJson(matrix.task.env) || '{}' }}
     secrets: inherit
-
-  build-docker-images:
-    name: Build Docker Images
-    needs: verify
-    uses: ./.github/workflows/build-docker-images.yaml
-    permissions:
-      contents: read
-      packages: write
-    with:
-      push: ${{ contains(github.event.pull_request.labels.*.name, 'build-docker') }}
-    secrets: inherit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized CI/CD workflows to separate concerns: coverage reporting and knip result reporting now run as dedicated workflows triggered after the main verification completes
  * Updated Docker image building triggers to activate on pull requests with the `build-docker` label (excluding forks)
  * Refined workflow permissions for reduced privilege scope

<!-- end of auto-generated comment: release notes by coderabbit.ai -->