### PR TITLE
fix(core): retry-library enqueues all pending items, not just the first

### DIFF
--- a/apps/riven/lib/state-machines/main-runner/__tests__/retry-library.spec.ts
+++ b/apps/riven/lib/state-machines/main-runner/__tests__/retry-library.spec.ts
@@ -1,58 +1,103 @@
-import { ItemRequest } from "@repo/util-plugin-sdk/dto/entities";
-
 import { expect, vi } from "vitest";
 import { waitFor } from "xstate";
 
+import { flow } from "../../../message-queue/flows/producer.ts";
 import { it } from "./helpers/test-context.ts";
 
-it.skip('sends a "riven.media-item.index.requested" event for each incomplete item request in the database', async ({
+it("enqueues every pending media item, not just the first", async ({
   actor,
+  factories: { movieFactory },
   em,
-  factories: { showItemRequestFactory, movieItemRequestFactory },
 }) => {
-  const items = [
-    movieItemRequestFactory.makeEntity({
-      imdbId: "tt1234567",
-      state: "requested",
-    }),
-    showItemRequestFactory.makeEntity({
-      imdbId: "tt2345678",
-      state: "requested",
-    }),
-    showItemRequestFactory.makeEntity({
-      imdbId: "tt3456789",
-      state: "failed",
-    }),
-  ];
+  // Three indexed movies — pre-fix this loop bailed after the first one.
+  const movies = await Promise.all([
+    movieFactory.makeOne({ state: "indexed" }),
+    movieFactory.makeOne({ state: "indexed" }),
+    movieFactory.makeOne({ state: "indexed" }),
+  ]);
+  await em.persistAndFlush(movies);
 
-  await em.getRepository(ItemRequest).insertMany(items);
+  const flowAddBulkSpy = vi.spyOn(flow, "addBulk");
 
   actor.start();
+  await waitFor(actor, (state) => state.matches("Running"));
 
+  // `riven-internal.retry-library` is also raised by the machine on entry to
+  // Running, but sending it explicitly avoids depending on event ordering.
+  actor.send({ type: "riven-internal.retry-library" });
+
+  await vi.waitFor(() => {
+    for (const movie of movies) {
+      expect(flowAddBulkSpy).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            queueName: "process-media-item",
+            data: expect.objectContaining({
+              mediaItem: expect.objectContaining({ id: movie.id }),
+            }),
+          }),
+        ]),
+      );
+    }
+  });
+});
+
+it("requests a scrape for media items in the indexed state", async ({
+  actor,
+  factories: { movieFactory },
+  em,
+}) => {
+  const movie = await movieFactory.makeOne({ state: "indexed" });
+  await em.persistAndFlush(movie);
+
+  const flowAddBulkSpy = vi.spyOn(flow, "addBulk");
+
+  actor.start();
   await waitFor(actor, (state) => state.matches("Running"));
 
   actor.send({ type: "riven-internal.retry-library" });
 
-  for (const item of items) {
-    await vi.waitFor(() => {
-      expect(actor).toHaveReceivedEvent({
-        type: `riven.media-item.index.requested.${item.type}`,
-        item: expect.objectContaining({
-          id: item.id,
-          imdbId: item.imdbId,
-          requestedBy: item.requestedBy,
+  await vi.waitFor(() => {
+    expect(flowAddBulkSpy).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          queueName: "process-media-item",
+          data: expect.objectContaining({
+            step: "scrape",
+            mediaItem: expect.objectContaining({ id: movie.id }),
+          }),
         }),
-      });
-    });
-  }
+      ]),
+    );
+  });
 });
 
-it.todo(
-  'does not send a "riven.media-item.index.requested" event for completed item requests',
-);
+it("requests a download for media items in the scraped state", async ({
+  actor,
+  factories: { movieFactory },
+  em,
+}) => {
+  const movie = await movieFactory.makeOne({ state: "scraped" });
+  await em.persistAndFlush(movie);
 
-it.todo('requests a scrape for each media item in the "Indexed" state');
+  const flowAddBulkSpy = vi.spyOn(flow, "addBulk");
 
-it.todo('requests a download for each media item in the "Scraped" state');
+  actor.start();
+  await waitFor(actor, (state) => state.matches("Running"));
 
-it.todo("does not send events for media items in other states");
+  actor.send({ type: "riven-internal.retry-library" });
+
+  await vi.waitFor(() => {
+    expect(flowAddBulkSpy).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          queueName: "process-media-item",
+          data: expect.objectContaining({
+            step: "download",
+            mediaItem: expect.objectContaining({ id: movie.id }),
+          }),
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/riven/lib/state-machines/main-runner/actors/retry-library.actor.ts
+++ b/apps/riven/lib/state-machines/main-runner/actors/retry-library.actor.ts
@@ -61,8 +61,6 @@ export const retryLibrary = fromPromise(async () => {
         id: item.id,
         step,
       });
-
-      break;
     }
   } catch (error) {
     logger.error("Error retrying library", { err: error });


### PR DESCRIPTION
## Summary
- Remove an unconditional `break` in the `retryLibrary` actor so the loop iterates the full `pendingItems` array.
- Introduced in #130; previously the loop processed every pending item.

## Why
On startup, `retry-library` is the only signal that re-enqueues media items in `indexed` / `scraped` / `partially_completed` states (it's raised exactly once in `main-runner/index.ts`, not on a timer). With the `break`, only **one** item is enqueued per process lifetime — a populated library that hasn't been freshly re-indexed stays mostly stuck across restarts.

Observed on a deployment with ~700 pending items: after each restart only one item progressed; the rest remained `scraped` indefinitely. Removing the `break` causes the backlog to drain end-to-end (and BullMQ's existing `jobId` dedup prevents duplicate enqueues if the same item is hit by a fan-out from elsewhere).

The companion `pendingRequests` loop above already iterates without a `break`, which is the shape this loop should match. The verbose log `Found N pending library items to retry` likewise advertises multi-item intent.

## Test plan
- [ ] `pnpm -r lint` — no warnings
- [ ] `pnpm --filter riven vitest run apps/riven/lib/state-machines/main-runner/__tests__/retry-library.spec.ts` — existing tests pass (note: the assertions for the `pendingItems` loop are currently `it.todo`; happy to follow up with coverage once stubbing `enqueueProcessMediaItem` from the test harness is agreed on)
- [x] Manual: on a backlog of ~700 pending items, after this fix the queue drains end-to-end instead of one-per-boot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry processing to enqueue all pending library media items instead of stopping after the first item.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rivenmedia/riven-ts/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->