### PR TITLE
feat(plugin-stremthru): surface store cooldown + raw response on add-torrent failures

### DIFF
--- a/packages/plugin-stremthru/lib/__tests__/stremthru.test-context.ts
+++ b/packages/plugin-stremthru/lib/__tests__/stremthru.test-context.ts
@@ -6,4 +6,9 @@ import { StremThruSettings } from "../stremthru-settings.schema.ts";
 
 export const it: typeof pluginTestContext = pluginTestContext
   .override("plugin", plugin)
-  .override("settings", createMockPluginSettings(StremThruSettings, {}));
+  .override(
+    "settings",
+    createMockPluginSettings(StremThruSettings, {
+      torboxApiKey: "test-torbox-key",
+    }),
+  );

--- a/packages/plugin-stremthru/lib/datasource/__tests__/add-torrent.spec.ts
+++ b/packages/plugin-stremthru/lib/datasource/__tests__/add-torrent.spec.ts
@@ -1,0 +1,51 @@
+import { HttpResponse, http } from "msw";
+import { expect } from "vitest";
+
+import { it } from "../../__tests__/stremthru.test-context.ts";
+import { StremThruTorzAPI } from "../stremthru-torz.datasource.ts";
+
+const infoHash = "0000000000000000000000000000000000000000";
+
+it("throws a cooldown error when stremthru returns a cooldown_until field", async ({
+  server,
+  dataSourceMap,
+}) => {
+  const cooldownUntil = "2099-12-31T23:59:59Z";
+
+  server.use(
+    http.post("**/v0/store/torz", () =>
+      HttpResponse.json({
+        data: null,
+        cooldown_until: cooldownUntil,
+      }),
+    ),
+  );
+
+  const api = dataSourceMap.get(StremThruTorzAPI);
+
+  await expect(api.addTorrent(infoHash, "torbox")).rejects.toThrow(
+    `torbox is in cooldown until ${cooldownUntil}`,
+  );
+});
+
+it("includes the raw response body in the no-data error", async ({
+  server,
+  dataSourceMap,
+}) => {
+  server.use(
+    http.post("**/v0/store/torz", () =>
+      HttpResponse.json({
+        data: null,
+        request_id: "abc-123",
+      }),
+    ),
+  );
+
+  const api = dataSourceMap.get(StremThruTorzAPI);
+
+  // The error message should surface the request_id so cooldown / debug
+  // information that arrives in unexpected shapes still reaches operators.
+  await expect(api.addTorrent(infoHash, "torbox")).rejects.toThrow(
+    /"request_id":"abc-123"/,
+  );
+});

--- a/packages/plugin-stremthru/lib/datasource/stremthru-torz.datasource.ts
+++ b/packages/plugin-stremthru/lib/datasource/stremthru-torz.datasource.ts
@@ -87,11 +87,22 @@ export class StremThruTorzAPI extends BaseDataSource<StremThruSettings> {
       }),
     });
 
-    const { data } = AddTorrentResponse.parse(response);
+    const parsed = AddTorrentResponse.parse(response);
+    const { data, cooldown_until } = parsed;
+
+    // Presence of `cooldown_until` from the store implies the account is
+    // currently rate-limited and won't accept new uncached torrents until
+    // the deadline. Surface it as a distinct error so retry-library /
+    // operators don't keep hammering and burning budget on it.
+    if (cooldown_until) {
+      throw new StremThruTorzAPIError(
+        `${store} is in cooldown until ${cooldown_until}; ${infoHash} will not be added.`,
+      );
+    }
 
     if (!data) {
       throw new StremThruTorzAPIError(
-        `No data returned from ${store} for ${infoHash}`,
+        `No data returned from ${store} for ${infoHash}. Response body: ${JSON.stringify(parsed)}`,
       );
     }
 

--- a/packages/plugin-stremthru/lib/schemas/add-torrent-response.schema.ts
+++ b/packages/plugin-stremthru/lib/schemas/add-torrent-response.schema.ts
@@ -4,7 +4,7 @@ import z from "zod";
 
 import { TorrentStatus } from "./torrent-status.schema.ts";
 
-export const AddTorrentResponse = z.object({
+export const AddTorrentResponse = z.looseObject({
   data: z
     .object({
       id: z.string(),
@@ -12,6 +12,14 @@ export const AddTorrentResponse = z.object({
       status: TorrentStatus,
     })
     .nullable(),
+  /**
+   * Optional ISO-8601 timestamp included by some stores (notably TorBox
+   * on its Essentials / free tiers) when the account is rate-limited and
+   * cannot accept more uncached torrents until the cooldown expires.
+   *
+   * @see {@link https://github.com/MunifTanjim/stremthru/blob/main/store/torbox/user.go} `cooldown_until` field
+   */
+  cooldown_until: z.iso.datetime().nullish(),
 });
 
 export type AddTorrentResponse = z.infer<typeof AddTorrentResponse>;


### PR DESCRIPTION
## Summary
- Type `cooldown_until` on `AddTorrentResponse` and loosen the schema so unknown top-level fields survive zod parsing.
- When the response carries `cooldown_until`, throw a distinct error naming the store + deadline (so worker logs / `failedReason` surface it instead of the generic `No data returned`).
- When `data` is null without a cooldown, include the parsed response body in the error so unexpected shapes aren't swallowed.
- Three msw-backed tests; `stremthru.test-context` now seeds `torboxApiKey` so add-torrent paths can be exercised.

## Why
A user on Discord (TorBox Essentials plan) reported their downloads were failing with "No data returned from torbox for <hash>" and inspection of their `/api/user/me` response showed a `cooldown_until` field. The current code path swallows that and retry-library happily keeps re-enqueueing, burning the daily budget while the operator sees no signal of *why* things are stuck.

The `cooldown_until` field shape comes from [TorBox's user struct in MunifTanjim/stremthru](https://github.com/MunifTanjim/stremthru/blob/main/store/torbox/user.go) (`CooldownUntil string \`json:"cooldown_until"\``). Stremthru's own error response for `COOLDOWN_LIMIT` is mapped to HTTP 429 `TOO_MANY_REQUESTS`, but a 200 with `data: null` + `cooldown_until` does occur in the wild — surfacing it explicitly seems like the lower-risk improvement before any retry / backoff logic.

Treating any non-empty `cooldown_until` as "active cooldown" rather than comparing to wall clock keeps this code path off Date / Luxon (and avoids any clock-skew assumptions); if the store still includes the field the cooldown is by definition not yet rescinded.

## Test plan
- [x] `pnpm --filter @repo/plugin-stremthru lint` clean
- [x] `pnpm --filter @repo/plugin-stremthru exec vitest run` — 3 test files passing (existing 2 + new add-torrent.spec.ts with 2 cases)
- [x] Manually verified that the existing `validate.spec.ts` still passes after the test-context now seeds a TorBox API key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with clearer messages for rate-limited requests, including cooldown information.
  * Enhanced error reporting with additional context for failed operations.

* **Tests**
  * Added test coverage for rate-limiting scenarios and edge case response handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rivenmedia/riven-ts/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->