### PR TITLE
chore(tmdb): add default api key

### DIFF
--- a/packages/plugin-tmdb/docs/settings.md
+++ b/packages/plugin-tmdb/docs/settings.md
@@ -4,8 +4,8 @@
 
 _Object containing the following properties:_
 
-| Property          | Description       | Type                       |
-| :---------------- | :---------------- | :------------------------- |
-| **`apiKey`** (\*) | Your TMDB API Key | `string` (_min length: 1_) |
+| Property | Description       | Type                       | Default                                                                                                                                                                                                                                             |
+| :------- | :---------------- | :------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiKey` | Your TMDB API Key | `string` (_min length: 1_) | `'eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI1ZjdiZDI5OGRkMTg4Y2Q0YzY5YmRkMGYxMDQ2ZGRjNCIsIm5iZiI6MTc3OTEwOTg1MS43NDgsInN1YiI6IjZhMGIwZmRiMmY3MWVhYzVkZmQ3ZmNkNyIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.GZtdnAqFW356rE3HJwQAkpQWs8s5hK2nY4hvRc2mDrY'` |
 
-_(\*) Required._
+_All properties are optional._

--- a/packages/plugin-tmdb/lib/tmdb-settings.schema.ts
+++ b/packages/plugin-tmdb/lib/tmdb-settings.schema.ts
@@ -4,6 +4,9 @@ export const TmdbSettings = z.object({
   apiKey: z
     .string()
     .min(1, "API Key is required")
+    .default(
+      "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI1ZjdiZDI5OGRkMTg4Y2Q0YzY5YmRkMGYxMDQ2ZGRjNCIsIm5iZiI6MTc3OTEwOTg1MS43NDgsInN1YiI6IjZhMGIwZmRiMmY3MWVhYzVkZmQ3ZmNkNyIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.GZtdnAqFW356rE3HJwQAkpQWs8s5hK2nY4hvRc2mDrY",
+    )
     .describe("Your TMDB API Key"),
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TMDB plugin settings documentation to reflect that all configuration properties, including the API key, are now optional rather than required. Default value for the API key is now documented.

* **Changes**
  * TMDB settings schema modified to include a default value for the API key field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rivenmedia/riven-ts/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->