### PR TITLE
fix(core): ensure collections are initialised after upsert

### DIFF
--- a/apps/riven/Dockerfile
+++ b/apps/riven/Dockerfile
@@ -18,6 +18,7 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-slim AS core-os
     ARG USER
     ARG PNPM_HOME
     ARG PNPM_VERSION
+    ARG TURBO_VERSION
     ARG HOME
 
     ENV PNPM_HOME=${PNPM_HOME}
@@ -38,6 +39,9 @@ FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-slim AS core-os
     # Install pnpm
     RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
+    RUN pnpm add turbo@${TURBO_VERSION} --global
+    RUN turbo telemetry disable
+
 FROM core-os AS prepare
 
     LABEL builder="true"
@@ -46,9 +50,6 @@ FROM core-os AS prepare
     ARG HOME
 
     WORKDIR ${HOME}
-
-    RUN pnpm add turbo@${TURBO_VERSION} --global
-    RUN turbo telemetry disable
 
     COPY . .
 

--- a/apps/riven/Dockerfile
+++ b/apps/riven/Dockerfile
@@ -46,7 +46,6 @@ FROM core-os AS prepare
 
     LABEL builder="true"
 
-    ARG TURBO_VERSION
     ARG HOME
 
     WORKDIR ${HOME}

--- a/apps/riven/Dockerfile
+++ b/apps/riven/Dockerfile
@@ -75,7 +75,7 @@ FROM core-os AS builder
     ARG TURBO_TEAM
     ENV TURBO_TEAM=${TURBO_TEAM}
 
-    RUN --mount=type=secret,id=TURBO_TOKEN,env=TURBO_TOKEN pnpm turbo @repo/riven#build
+    RUN --mount=type=secret,id=TURBO_TOKEN,env=TURBO_TOKEN turbo @repo/riven#build
 
 FROM builder AS production-deploy
 

--- a/apps/riven/lib/database/services/indexer/utilities/persist-show-indexer-data.ts
+++ b/apps/riven/lib/database/services/indexer/utilities/persist-show-indexer-data.ts
@@ -90,6 +90,7 @@ export async function persistShowIndexerData(
       genres: item.genres.map((genre) => genre.toLowerCase()),
       nextAirDate: null, // Reset the next air date; it will be recalculated during episode processing
       indexedAt,
+      seasons: [],
     });
 
     await em.upsert(Show, show, {
@@ -120,6 +121,7 @@ export async function persistShowIndexerData(
           : season.number > 0,
         itemRequest,
         indexedAt,
+        episodes: [],
       });
 
       show.seasons.add(seasonEntry);

--- a/apps/riven/lib/database/subscribers/show-like-media-item-release-date.subscriber.ts
+++ b/apps/riven/lib/database/subscribers/show-like-media-item-release-date.subscriber.ts
@@ -23,10 +23,6 @@ export class ShowLikeMediaItemReleaseDateSubscriber implements EventSubscriber {
 
     for (const collectionUpdate of uow.getCollectionUpdates()) {
       if (collectionUpdate.owner instanceof Season) {
-        if (!collectionUpdate.isInitialized()) {
-          await collectionUpdate.init();
-        }
-
         const collectionEpisodes = collectionUpdate.filter(
           (episode): episode is Partial<Episode> =>
             episode instanceof Episode && episode.releaseDate != null,


### PR DESCRIPTION
https://github.com/mikro-orm/mikro-orm/pull/7718 changed the `upsert` behaviour to reset untouched collections, which caused the indexer persistence to throw errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data persistence and collection initialization during show indexing operations to ensure proper handling of season and episode data relationships.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rivenmedia/riven-ts/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->