### PR TITLE
fix(wiki): update ts image tag to main

### DIFF
--- a/apps/wiki/components/docker-compose-generator.tsx
+++ b/apps/wiki/components/docker-compose-generator.tsx
@@ -89,7 +89,7 @@ function buildTSCompose(cfg: TSConfig): {
     },
     services: {
       riven: {
-        image: "ghcr.io/rivenmedia/riven-ts:latest",
+        image: "ghcr.io/rivenmedia/riven-ts:main",
         container_name: "riven",
         restart: "unless-stopped",
         tty: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker Compose configuration to use the `main` image tag for the riven service instead of `latest`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rivenmedia/riven-ts/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->