### PR TITLE
fix(wiki): bad container name in generator

### DIFF
--- a/apps/wiki/components/docker-compose-generator.tsx
+++ b/apps/wiki/components/docker-compose-generator.tsx
@@ -147,10 +147,10 @@ function buildTSCompose(cfg: TSConfig): {
           ports: ["4000:4000"],
           environment: {
             PORT: "4000",
-            REDIS_HOST: "riven-cache",
+            REDIS_HOST: "redis",
           },
           depends_on: {
-            "riven-cache": {
+            redis: {
               condition: "service_healthy",
             },
           },
@@ -160,7 +160,7 @@ function buildTSCompose(cfg: TSConfig): {
           image: "redislabs/redisinsight:latest",
           restart: "unless-stopped",
           environment: {
-            RI_REDIS_HOST: "riven-cache",
+            RI_REDIS_HOST: "redis",
           },
           ports: ["5540:5540"],
           healthcheck: {
@@ -174,7 +174,7 @@ function buildTSCompose(cfg: TSConfig): {
             retries: 3,
           },
           depends_on: {
-            "riven-cache": { condition: "service_healthy" },
+            redis: { condition: "service_healthy" },
           },
         },
       }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Docker Compose generator to properly reference the Redis container for analytics services, ensuring bullboard and redis-insight configurations initialize correctly and maintain proper service dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rivenmedia/riven-ts/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->