### PR TITLE
fix(codegen): don't require runtime settings to generate the GraphQL schema

### DIFF
--- a/apps/riven/scripts/generate-gql-schema.ts
+++ b/apps/riven/scripts/generate-gql-schema.ts
@@ -1,6 +1,14 @@
-import { buildSchema } from "@repo/core-util-graphql-schema";
+// Importing the resolver graph eagerly constructs the core Settings object,
+// which throws when the required RIVEN_SETTING__* values are absent. Emitting
+// the schema needs only the resolver types, so set harmless placeholders here;
+// real values come from the runtime env_file.
+process.env.RIVEN_SETTING__databaseUrl ??=
+  "postgresql://build:build@localhost:5432/build";
+process.env.RIVEN_SETTING__redisUrl ??= "redis://localhost:6379";
+process.env.RIVEN_SETTING__vfsMountPath ??= "/mnt/riven";
 
-import { resolvers } from "../lib/graphql/resolvers/index.ts";
+const { buildSchema } = await import("@repo/core-util-graphql-schema");
+const { resolvers } = await import("../lib/graphql/resolvers/index.ts");
 
 await buildSchema({
   resolvers,


### PR DESCRIPTION
`codegen:gql-schema` imports the resolver graph to emit `schema.graphql`. Importing it eagerly constructs the core `Settings` object, which parses `RIVEN_SETTING__*` and throws a `ZodError` when `databaseUrl` / `redisUrl` / `vfsMountPath` aren't set.

In practice the schema only generates on a turbo cache hit — any change that invalidates the codegen cache without runtime settings in the env (a clean CI checkout, a cold Docker build) fails the build.

Schema generation only needs the resolver types, not real settings values, so this sets harmless build-time placeholders before importing the graph (real values still come from the runtime env_file), with the imports made dynamic so they apply first. No runtime behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential schema generation failures that occurred when required environment variables were absent. The build process now initializes gracefully with sensible defaults.

* **Chores**
  * Refactored schema generation script to use dynamic imports for improved build process flexibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->