### PR TITLE
feat(download): skip Real-Debrid for legally-filtered release names

### DIFF
--- a/apps/riven/lib/message-queue/flows/process-media-item/steps/download/steps/find-valid-torrent/find-valid-torrent.processor.ts
+++ b/apps/riven/lib/message-queue/flows/process-media-item/steps/download/steps/find-valid-torrent/find-valid-torrent.processor.ts
@@ -13,6 +13,7 @@ import { createJobParentConfig } from "../../../../../../utilities/create-job-pa
 import { filterChildrenValues } from "../../../../../../utilities/filter-children-values.ts";
 import { findValidTorrentProcessorSchema } from "./find-valid-torrent.schema.ts";
 import { getCachedTorrentFiles } from "./utilities/get-cached-torrent-files.ts";
+import { matchesRealdebridFilter } from "./utilities/matches-realdebrid-filter.ts";
 import { getPluginDownloadResult } from "./utilities/get-plugin-download-result.ts";
 import { getPluginProviderList } from "./utilities/get-plugin-provider-list.ts";
 import { getValidTorrentFiles } from "./utilities/get-valid-torrent-files.ts";
@@ -46,6 +47,11 @@ export const findValidTorrentProcessor =
     const infoHashes = rankedStreams.map((stream) => stream.hash);
     const uncheckedInfoHashes = new Set(infoHashes).difference(
       new Set(failedInfoHashes),
+    );
+
+    // Release name per info hash, used to skip Real-Debrid legal-filter matches below.
+    const rawTitleByHash = new Map(
+      rankedStreams.map((stream) => [stream.hash, stream.data.rawTitle]),
     );
 
     const parent = createJobParentConfig(job);
@@ -149,6 +155,30 @@ export const findValidTorrentProcessor =
               );
 
               continue;
+            }
+
+            // Real-Debrid legally filters certain release-name patterns and serves
+            // 451 for them, which would blacklist + reset the item. Skip RD for any
+            // matching release; it still gets tried on the other stores.
+            if (
+              provider === "realdebrid" &&
+              settings.realdebridFilenameBlocklist.length > 0
+            ) {
+              const rawTitle = rawTitleByHash.get(infoHash);
+
+              if (
+                rawTitle &&
+                matchesRealdebridFilter(
+                  rawTitle,
+                  settings.realdebridFilenameBlocklist,
+                )
+              ) {
+                logger.debug(
+                  `Skipping ${infoHash} on realdebrid; release name matches RD legal filter`,
+                );
+
+                continue;
+              }
             }
 
             scope.setTag("riven.downloader-provider", provider);

--- a/apps/riven/lib/message-queue/flows/process-media-item/steps/download/steps/find-valid-torrent/utilities/matches-realdebrid-filter.spec.ts
+++ b/apps/riven/lib/message-queue/flows/process-media-item/steps/download/steps/find-valid-torrent/utilities/matches-realdebrid-filter.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { matchesRealdebridFilter } from "./matches-realdebrid-filter.ts";
+
+const RD_BLOCKLIST = [
+  "web-dl",
+  "webrip",
+  "bdrip",
+  "hdrip",
+  "dvdrip",
+  "bluray.x264",
+  "hdtv.x264",
+  "hdtv.xvid",
+  "web.x264",
+  "web.h264",
+] as const;
+
+describe("matchesRealdebridFilter", () => {
+  it("matches Type 1 bare substrings", () => {
+    expect(
+      matchesRealdebridFilter("Movie.2018.1080p.WEB-DL.DDP5.1-GRP", RD_BLOCKLIST),
+    ).toBe(true);
+    expect(
+      matchesRealdebridFilter("Movie.2018.720p.WEBRip.x265-GRP", RD_BLOCKLIST),
+    ).toBe(true);
+    expect(
+      matchesRealdebridFilter("Movie.1998.DVDRip.XviD-GRP", RD_BLOCKLIST),
+    ).toBe(true);
+  });
+
+  it("matches Type 2 adjacent dot-separated source.codec pairs", () => {
+    expect(
+      matchesRealdebridFilter("Movie.2010.1080p.BluRay.x264-GRP", RD_BLOCKLIST),
+    ).toBe(true);
+    expect(
+      matchesRealdebridFilter("Show.S01E01.HDTV.XviD-GRP", RD_BLOCKLIST),
+    ).toBe(true);
+    expect(
+      matchesRealdebridFilter("Show.S01E01.WEB.h264-GRP", RD_BLOCKLIST),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(
+      matchesRealdebridFilter("MOVIE.2010.1080P.BLURAY.X264-GRP", RD_BLOCKLIST),
+    ).toBe(true);
+  });
+
+  it("requires the dot for Type 2 (the . enforces adjacency)", () => {
+    // "webx264" (no dot) must NOT match the "web.x264" pattern
+    expect(matchesRealdebridFilter("Movie.2010.WEBx264-GRP", RD_BLOCKLIST)).toBe(
+      false,
+    );
+  });
+
+  it("passes clean releases that RD does not filter", () => {
+    expect(
+      matchesRealdebridFilter(
+        "Movie.2010.2160p.BluRay.REMUX.HEVC.TrueHD.7.1-GRP",
+        RD_BLOCKLIST,
+      ),
+    ).toBe(false);
+    expect(
+      matchesRealdebridFilter("Movie.2010.1080p.BluRay.x265-GRP", RD_BLOCKLIST),
+    ).toBe(false);
+  });
+
+  it("matches nothing when the blocklist is empty", () => {
+    expect(matchesRealdebridFilter("Movie.2018.1080p.WEB-DL-GRP", [])).toBe(
+      false,
+    );
+  });
+});

--- a/apps/riven/lib/message-queue/flows/process-media-item/steps/download/steps/find-valid-torrent/utilities/matches-realdebrid-filter.ts
+++ b/apps/riven/lib/message-queue/flows/process-media-item/steps/download/steps/find-valid-torrent/utilities/matches-realdebrid-filter.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns true if a release name matches any entry in Real-Debrid's legal-filter
+ * blocklist. RD rejects certain release-name patterns with HTTP 451, so a match
+ * means the release should be skipped on RD (and tried on other stores instead).
+ *
+ * Matching is a plain case-insensitive substring test. This covers both of RD's
+ * known rules: bare substrings (e.g. `web-dl`, `webrip`) and source+codec pairs
+ * that must be dot-separated and adjacent (e.g. `web.x264`) — the literal `.` in
+ * the pattern enforces the adjacency, so `webx264` does not match `web.x264`.
+ */
+export function matchesRealdebridFilter(
+  rawTitle: string,
+  blocklist: readonly string[],
+): boolean {
+  const lower = rawTitle.toLowerCase();
+
+  return blocklist.some((pattern) => lower.includes(pattern.toLowerCase()));
+}

--- a/apps/riven/lib/riven-settings.schema.ts
+++ b/apps/riven/lib/riven-settings.schema.ts
@@ -129,6 +129,18 @@ export const RivenSettings = z.object({
       "The maximum number of scrape attempts before giving up on an item.",
     )
     .meta({ "wiki.section": "scraping" }),
+  realdebridFilenameBlocklist: json(z.array(z.string()))
+    .default([])
+    .describe(
+      dedent`
+        Case-insensitive substrings that cause a release to be skipped **on Real-Debrid only**.
+
+        Real-Debrid legally filters certain release names and returns 451 for them; selecting such a
+        release on RD causes riven to blacklist and reset the item. Listing those substrings here
+        makes RD skip matching releases (they still download on other stores). Empty disables the filter.
+      `,
+    )
+    .meta({ "wiki.section": "scraping" }),
   minimumAverageBitrateMovies: z
     .int()
     .positive()


### PR DESCRIPTION
## Problem

Real-Debrid legally filters certain release-name patterns and returns `451 Unavailable For Legal Reasons` for them. When riven selects an RD-cached torrent whose name matches RD's filter, the 451 propagates to `blacklistActiveStream` then `MediaItem.reset()`, which removes the item's filesystem entries, streams, and subtitles and demotes it from `completed` to `indexed`. Because a Plex library scan opens every file, a single scan can demote a large fraction of a library in one pass, and re-fetch all of its subtitles afterward. (See #202 for the reset-hardening side of this.)

The patterns RD rejects are predictable and fall into two case-insensitive rules:

- Bare substrings anywhere in the name: `web-dl`, `webrip`, `bdrip`, `hdrip`, `dvdrip`
- A source tag and codec tag that are dot-separated and directly adjacent: `bluray.x264`, `hdtv.x264`, `hdtv.xvid`, `web.x264`, `web.h264`

## Change

Add a configurable, Real-Debrid-scoped substring blocklist, `realdebridFilenameBlocklist` (default empty, so behavior is unchanged unless configured). It is checked in `find-valid-torrent`'s provider loop, the one place where both the store and the release name are known: a candidate whose release name matches any blocklist entry is skipped on Real-Debrid only, and still downloads on the other configured stores.

A plain case-insensitive substring test covers both rules. The second rule is just a literal substring that contains a `.` (e.g. `web.x264`), and the embedded dot enforces the adjacency requirement, so `webx264` does not match.

## Why scoped to Real-Debrid

A global Torrentio/RTN filter would be wrong here: `web-dl`, `webrip`, and similar are perfectly good releases that Premiumize and TorBox serve without issue. Only Real-Debrid filters them, so the check has to be per-store, which is why it lives in the provider loop rather than in ranking.

## Notes

- Default is an empty list, so this is opt-in and changes nothing for existing users until they populate it.
- Includes a unit test for the matcher covering both rules, case-insensitivity, the dot-adjacency guard, and clean releases passing through.
- Complements #202: that issue is about making the reset itself less destructive; this PR removes the trigger for the most common cause.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable Real-Debrid filename blocklist that filters torrent releases matching specified patterns. The system skips Real-Debrid results containing blocklisted patterns with case-insensitive matching. Leave empty to disable filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->