### PR TITLE
chore(repo): add deps scope

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -21,7 +21,7 @@ function stripPrefix(name: string) {
 }
 
 function getScopes() {
-  const scopes = new Set(["repo"]);
+  const scopes = new Set(["repo", "deps"]);
 
   // Get scopes from apps directory
   for (const dir of getDirNames("apps")) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated commitlint configuration to allow the "deps" scope in commit messages alongside the existing "repo" scope, expanding available options for commit categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->