### PR TITLE
fix(core): reconnect stream on seek to prevent buffering and playback corruption

### DIFF
--- a/apps/riven/lib/vfs/utilities/read-types/perform-body-read.ts
+++ b/apps/riven/lib/vfs/utilities/read-types/perform-body-read.ts
@@ -45,15 +45,33 @@ export async function performBodyRead(
     ].join(" | "),
   );
 
+  const requiredStart = missingChunksMetadata[0].range[0];
+  const existingStreamPromise = fdToResponsePromiseMap.get(fd);
+  const existingStreamPosition = fdToCurrentStreamPositionMap.get(fd);
+
+  if (
+    existingStreamPromise !== undefined &&
+    existingStreamPosition !== requiredStart
+  ) {
+    logger.debug(
+      `fd=${fd.toString()} stream misaligned (at ${existingStreamPosition?.toString() ?? "unknown"}, need ${requiredStart.toString()}) — reconnecting`,
+    );
+
+    fdToResponsePromiseMap.delete(fd);
+    fdToCurrentStreamPositionMap.delete(fd);
+
+    // Drain without blocking. We don't want a slow or large stream to delay the reconnect.
+    void existingStreamPromise
+      .then((r) => r.body.dump())
+      .catch(() => undefined);
+  }
+
   const streamReader =
     (await fdToResponsePromiseMap.get(fd)) ??
-    (await createStreamRequest(fileHandle.url, [
-      missingChunksMetadata[0].range[0],
-      undefined,
-    ]));
+    (await createStreamRequest(fileHandle.url, [requiredStart, undefined]));
 
   if (!fdToCurrentStreamPositionMap.has(fd)) {
-    fdToCurrentStreamPositionMap.set(fd, missingChunksMetadata[0].range[0]);
+    fdToCurrentStreamPositionMap.set(fd, requiredStart);
   }
 
   const currentStreamPosition = fdToCurrentStreamPositionMap.get(fd);


### PR DESCRIPTION
### Bug Description
When seeking, performBodyRead was reusing the existing HTTP stream even when it was positioned at the wrong byte offset. The stream would then read data from the old position, cache it under the chunk key for the new position, and deliver those wrong bytes to Plex.

### Main Issue This Caused
Depending on the client, long seeks appeared to cause either indefinite buffering (#106) or audio/visual desync + artifacts

### Fix
Before reusing the stream, `performBodyRead` now checks whether the stream's tracked byte offset matches the start of the chunk being requested. If it doesn't (which is true after any seek landing on a different chunk boundary), the misaligned stream is discarded, and a new request is opened from the correct position. The old stream is drained in the background, so the connection is released cleanly.

Fixes #106 

