### PR TITLE
fix(core): reconnect stream on seek to prevent buffering and playback corruption

### DIFF
--- a/apps/riven/lib/vfs/operations/read.spec.ts
+++ b/apps/riven/lib/vfs/operations/read.spec.ts
@@ -8,6 +8,7 @@ import { chunkCache } from "../utilities/chunk-cache.ts";
 import { calculateFileChunks } from "../utilities/chunks/calculate-file-chunks.ts";
 import { createChunkCacheKey } from "../utilities/chunks/create-chunk-cache-key.ts";
 import {
+  fdToCurrentStreamPositionMap,
   fdToFileHandleMeta,
   fdToPreviousReadPositionMap,
   fdToResponsePromiseMap,
@@ -59,6 +60,7 @@ function setupRangeInterceptor(
 it.beforeEach(() => {
   fdToFileHandleMeta.clear();
   fdToResponsePromiseMap.clear();
+  fdToCurrentStreamPositionMap.clear();
   fileNameToFileChunkCalculationsMap.clear();
   fdToPreviousReadPositionMap.clear();
 

--- a/apps/riven/lib/vfs/operations/read.ts
+++ b/apps/riven/lib/vfs/operations/read.ts
@@ -11,6 +11,7 @@ import {
   fdToCurrentStreamPositionMap,
   fdToFileHandleMeta,
   fdToPreviousReadPositionMap,
+  fdToResponsePromiseMap,
   fileNameToFileChunkCalculationsMap,
 } from "../utilities/file-handle-map.ts";
 import { performBodyRead } from "../utilities/read-types/perform-body-read.ts";
@@ -22,29 +23,37 @@ import {
 import { withVfsScope } from "../utilities/with-vfs-scope.ts";
 
 async function read() {
-  const { buffer, fd, length, position } = getVfsOperationContext("read");
-  const fileHandle = fdToFileHandleMeta.get(fd);
-
-  if (!fileHandle) {
-    throw new FuseError(Fuse.EBADF, "Invalid file handle");
-  }
+  const {
+    buffer,
+    fd,
+    length,
+    position,
+    context: {
+      fileHandleMetadata,
+      previousReadPosition,
+      currentStreamPosition,
+    },
+  } = getVfsOperationContext("read");
 
   // Subtitle files are served directly from an in-memory buffer
-  if (fileHandle.type === "subtitle") {
-    const end = Math.min(position + length, fileHandle.contentBuffer.length);
+  if (fileHandleMetadata.type === "subtitle") {
+    const end = Math.min(
+      position + length,
+      fileHandleMetadata.contentBuffer.length,
+    );
     const bytesRead = end - position;
 
     if (bytesRead <= 0) {
       return 0;
     }
 
-    fileHandle.contentBuffer.copy(buffer, 0, position, end);
+    fileHandleMetadata.contentBuffer.copy(buffer, 0, position, end);
 
     return bytesRead;
   }
 
   const fileChunkCalculations = fileNameToFileChunkCalculationsMap.get(
-    fileHandle.originalFileName,
+    fileHandleMetadata.originalFileName,
   );
 
   if (!fileChunkCalculations) {
@@ -58,12 +67,10 @@ async function read() {
     },
   } = calculateChunkRange({
     chunkSize: config.chunkSize,
-    fileSize: fileHandle.fileSize,
+    fileSize: fileHandleMetadata.fileSize,
     requestRange: [position, position + length - 1],
-    fileName: fileHandle.originalFileName,
+    fileName: fileHandleMetadata.originalFileName,
   });
-
-  const previousReadPosition = fdToPreviousReadPositionMap.get(fd);
 
   const readType = detectReadType(
     previousReadPosition,
@@ -71,8 +78,6 @@ async function read() {
     length,
     fileChunkCalculations,
   );
-
-  const currentStreamPosition = fdToCurrentStreamPositionMap.get(fd);
 
   logger.silly(
     [
@@ -90,7 +95,7 @@ async function read() {
   switch (readType) {
     case "header-scan": {
       const data = await fetchDiscreteByteRange(
-        fileHandle,
+        fileHandleMetadata,
         fileChunkCalculations.headerChunk.range,
       );
 
@@ -113,7 +118,7 @@ async function read() {
     case "footer-read":
     case "footer-scan": {
       const data = await fetchDiscreteByteRange(
-        fileHandle,
+        fileHandleMetadata,
         fileChunkCalculations.footerChunk.range,
       );
 
@@ -129,7 +134,7 @@ async function read() {
 
     case "general-scan": {
       const scannedChunk = await fetchDiscreteByteRange(
-        fileHandle,
+        fileHandleMetadata,
         [position, position + length - 1],
         false,
       );
@@ -140,7 +145,7 @@ async function read() {
     }
 
     case "body-read": {
-      const data = await performBodyRead(chunks, fileHandle);
+      const data = await performBodyRead(chunks);
 
       data.copy(
         buffer,
@@ -179,8 +184,14 @@ export const readSync = function (
   position,
   callback,
 ) {
-  void withVfsScope(() =>
-    withVfsOperationContext(
+  void withVfsScope(() => {
+    const fileHandleMetadata = fdToFileHandleMeta.get(fd);
+
+    if (!fileHandleMetadata) {
+      throw new FuseError(Fuse.EBADF, "Invalid file handle");
+    }
+
+    return withVfsOperationContext(
       {
         operationName: "read",
         path,
@@ -188,6 +199,12 @@ export const readSync = function (
         buffer,
         length,
         position,
+        context: {
+          fileHandleMetadata,
+          previousReadPosition: fdToPreviousReadPositionMap.get(fd),
+          currentStreamPosition: fdToCurrentStreamPositionMap.get(fd),
+          responsePromise: fdToResponsePromiseMap.get(fd),
+        },
       },
       async () => {
         const bytesRead = await read();
@@ -217,6 +234,6 @@ export const readSync = function (
       });
 
       process.nextTick(callback, Fuse.EIO);
-    }),
-  );
+    });
+  });
 } satisfies OPERATIONS["read"];

--- a/apps/riven/lib/vfs/utilities/chunks/wait-for-chunk.ts
+++ b/apps/riven/lib/vfs/utilities/chunks/wait-for-chunk.ts
@@ -28,6 +28,13 @@ export const waitForChunk = async (
   const timeoutSignal = AbortSignal.timeout(config.chunkTimeoutSeconds * 1000);
 
   while ((chunk = reader.read(targetChunk.size) as Buffer | null) === null) {
+    if (reader.readableAborted) {
+      throw new FuseError(
+        Fuse.EIO,
+        `Stream was aborted while waiting for chunk ${targetChunk.rangeLabel}`,
+      );
+    }
+
     if (timeoutSignal.aborted) {
       throw new FuseError(
         Fuse.ETIMEDOUT,

--- a/apps/riven/lib/vfs/utilities/chunks/wait-for-chunk.ts
+++ b/apps/riven/lib/vfs/utilities/chunks/wait-for-chunk.ts
@@ -20,7 +20,10 @@ export const waitForChunk = async (
   reader: BodyReadable.default,
   targetChunk: ChunkMetadata,
 ): Promise<WaitForChunkResponse> => {
-  const { fd } = getVfsOperationContext("read");
+  const {
+    fd,
+    context: { currentStreamPosition = 0 },
+  } = getVfsOperationContext("read");
 
   let chunk: Buffer | null = null;
   let fetchedFromCache = false;
@@ -31,7 +34,7 @@ export const waitForChunk = async (
     if (reader.readableAborted) {
       throw new FuseError(
         Fuse.EIO,
-        `Stream was aborted while waiting for chunk ${targetChunk.rangeLabel}`,
+        `Stream was aborted before chunk could be read ${targetChunk.rangeLabel}`,
       );
     }
 
@@ -57,8 +60,6 @@ export const waitForChunk = async (
   }
 
   if (!fetchedFromCache) {
-    const currentStreamPosition = fdToCurrentStreamPositionMap.get(fd) ?? 0;
-
     fdToCurrentStreamPositionMap.set(
       fd,
       currentStreamPosition + chunk.byteLength,

--- a/apps/riven/lib/vfs/utilities/read-types/perform-body-read.ts
+++ b/apps/riven/lib/vfs/utilities/read-types/perform-body-read.ts
@@ -51,10 +51,11 @@ export async function performBodyRead(
 
   if (
     existingStreamPromise !== undefined &&
+    existingStreamPosition !== undefined &&
     existingStreamPosition !== requiredStart
   ) {
     logger.debug(
-      `fd=${fd.toString()} stream misaligned (at ${existingStreamPosition?.toString() ?? "unknown"}, need ${requiredStart.toString()}) — reconnecting`,
+      `fd=${fd.toString()} stream misaligned (at ${existingStreamPosition.toString()}, need ${requiredStart.toString()}) — reconnecting`,
     );
 
     fdToResponsePromiseMap.delete(fd);

--- a/apps/riven/lib/vfs/utilities/read-types/perform-body-read.ts
+++ b/apps/riven/lib/vfs/utilities/read-types/perform-body-read.ts
@@ -45,15 +45,33 @@ export async function performBodyRead(
     ].join(" | "),
   );
 
+  const requiredStart = missingChunksMetadata[0].range[0];
+  const existingStreamPromise = fdToResponsePromiseMap.get(fd);
+  const existingStreamPosition = fdToCurrentStreamPositionMap.get(fd);
+
+  if (
+    existingStreamPromise !== undefined &&
+    existingStreamPosition !== requiredStart
+  ) {
+    logger.debug(
+      `fd=${fd.toString()} stream misaligned (at ${existingStreamPosition?.toString() ?? "unknown"}, need ${requiredStart.toString()}) — reconnecting`,
+    );
+
+    fdToResponsePromiseMap.delete(fd);
+    fdToCurrentStreamPositionMap.delete(fd);
+
+    // Drain without blocking. We don't want a slow or large stream to delay the reconnect.
+    void existingStreamPromise
+      .then((r) => r.body.dump())
+      .catch(() => undefined);
+  }
+
   const streamReader =
     (await fdToResponsePromiseMap.get(fd)) ??
-    (await createStreamRequest(fileHandle.url, [
-      missingChunksMetadata[0].range[0],
-      undefined,
-    ]));
+    (await createStreamRequest(fileHandle.url, [requiredStart, undefined]));
 
   if (!fdToCurrentStreamPositionMap.has(fd)) {
-    fdToCurrentStreamPositionMap.set(fd, missingChunksMetadata[0].range[0]);
+    fdToCurrentStreamPositionMap.set(fd, requiredStart);
   }
 
   const currentStreamPosition = fdToCurrentStreamPositionMap.get(fd);

--- a/apps/riven/lib/vfs/utilities/read-types/perform-body-read.ts
+++ b/apps/riven/lib/vfs/utilities/read-types/perform-body-read.ts
@@ -13,6 +13,7 @@ import {
   fdToResponsePromiseMap,
 } from "../file-handle-map.ts";
 import { createStreamRequest } from "../requests/create-stream-request.ts";
+import { seek } from "../seek.ts";
 import { getVfsOperationContext } from "../vfs-operation-context.ts";
 
 import type { ChunkMetadata } from "../../schemas/chunk.schema.ts";
@@ -45,40 +46,19 @@ export async function performBodyRead(
     ].join(" | "),
   );
 
-  const requiredStart = missingChunksMetadata[0].range[0];
-  const existingStreamPromise = fdToResponsePromiseMap.get(fd);
-  const existingStreamPosition = fdToCurrentStreamPositionMap.get(fd);
+  const [chunkAlignedStart] = missingChunksMetadata[0].range;
+  const currentStreamPosition = fdToCurrentStreamPositionMap.get(fd);
 
-  if (
-    existingStreamPromise !== undefined &&
-    existingStreamPosition !== undefined &&
-    existingStreamPosition !== requiredStart
-  ) {
-    logger.debug(
-      `fd=${fd.toString()} stream misaligned (at ${existingStreamPosition.toString()}, need ${requiredStart.toString()}) — reconnecting`,
-    );
-
-    fdToResponsePromiseMap.delete(fd);
-    fdToCurrentStreamPositionMap.delete(fd);
-
-    // Drain without blocking. We don't want a slow or large stream to delay the reconnect.
-    void existingStreamPromise
-      .then((r) => r.body.dump())
-      .catch(() => undefined);
+  if (currentStreamPosition && currentStreamPosition !== chunkAlignedStart) {
+    seek(currentStreamPosition, chunkAlignedStart);
   }
 
   const streamReader =
     (await fdToResponsePromiseMap.get(fd)) ??
-    (await createStreamRequest(fileHandle.url, [requiredStart, undefined]));
+    (await createStreamRequest(fileHandle.url, [chunkAlignedStart, undefined]));
 
   if (!fdToCurrentStreamPositionMap.has(fd)) {
-    fdToCurrentStreamPositionMap.set(fd, requiredStart);
-  }
-
-  const currentStreamPosition = fdToCurrentStreamPositionMap.get(fd);
-
-  if (currentStreamPosition === undefined) {
-    throw new FuseError(Fuse.EIO, "Missing current stream position");
+    fdToCurrentStreamPositionMap.set(fd, chunkAlignedStart);
   }
 
   const {

--- a/apps/riven/lib/vfs/utilities/read-types/perform-body-read.ts
+++ b/apps/riven/lib/vfs/utilities/read-types/perform-body-read.ts
@@ -1,17 +1,14 @@
 import { benchmark } from "@repo/util-plugin-sdk/helpers/benchmark";
 
 import Fuse from "@zkochan/fuse-native";
+import assert from "node:assert";
 import { Buffer } from "node:buffer";
 
 import { logger } from "../../../utilities/logger/logger.ts";
 import { FuseError } from "../../errors/fuse-error.ts";
 import { chunkCache } from "../chunk-cache.ts";
 import { waitForChunk } from "../chunks/wait-for-chunk.ts";
-import {
-  type MediaFileHandleMetadata,
-  fdToCurrentStreamPositionMap,
-  fdToResponsePromiseMap,
-} from "../file-handle-map.ts";
+import { fdToCurrentStreamPositionMap } from "../file-handle-map.ts";
 import { createStreamRequest } from "../requests/create-stream-request.ts";
 import { seek } from "../seek.ts";
 import { getVfsOperationContext } from "../vfs-operation-context.ts";
@@ -24,14 +21,22 @@ import type { ChunkMetadata } from "../../schemas/chunk.schema.ts";
  * from the stream, which are then stitched together with any cached chunks.
  *
  * @param chunks The chunks that form the request
- * @param fileHandle The file handle metadata for the file descriptor
  * @returns The requests chunk data
  */
-export async function performBodyRead(
-  chunks: readonly ChunkMetadata[],
-  fileHandle: MediaFileHandleMetadata,
-) {
-  const { fd } = getVfsOperationContext("read");
+export async function performBodyRead(chunks: readonly ChunkMetadata[]) {
+  const {
+    fd,
+    context: { fileHandleMetadata, currentStreamPosition, responsePromise },
+  } = getVfsOperationContext("read");
+
+  assert(
+    fileHandleMetadata.type !== "subtitle",
+    new FuseError(
+      Fuse.EIO,
+      "Body read should not be performed for subtitle files",
+    ),
+  );
+
   const cachedChunksMetadata = chunks.filter((chunk) => chunk.isCached);
   const missingChunksMetadata = chunks.filter((chunk) => !chunk.isCached);
 
@@ -47,15 +52,17 @@ export async function performBodyRead(
   );
 
   const [chunkAlignedStart] = missingChunksMetadata[0].range;
-  const currentStreamPosition = fdToCurrentStreamPositionMap.get(fd);
 
   if (currentStreamPosition && currentStreamPosition !== chunkAlignedStart) {
     seek(currentStreamPosition, chunkAlignedStart);
   }
 
   const streamReader =
-    (await fdToResponsePromiseMap.get(fd)) ??
-    (await createStreamRequest(fileHandle.url, [chunkAlignedStart, undefined]));
+    (await responsePromise) ??
+    (await createStreamRequest(fileHandleMetadata.url, [
+      chunkAlignedStart,
+      undefined,
+    ]));
 
   if (!fdToCurrentStreamPositionMap.has(fd)) {
     fdToCurrentStreamPositionMap.set(fd, chunkAlignedStart);

--- a/apps/riven/lib/vfs/utilities/seek.ts
+++ b/apps/riven/lib/vfs/utilities/seek.ts
@@ -1,0 +1,30 @@
+import { logger } from "../../utilities/logger/logger.ts";
+import {
+  fdToCurrentStreamPositionMap,
+  fdToResponsePromiseMap,
+} from "./file-handle-map.ts";
+import { getVfsOperationContext } from "./vfs-operation-context.ts";
+
+/**
+ * Handles a stream seek when reusing an existing file descriptor.
+ *
+ * Closes the existing stream and opens a new one from the new position.
+ *
+ * @param from The previous stream position
+ * @param to The new stream position
+ */
+export function seek(from: number, to: number) {
+  const { fd } = getVfsOperationContext("read");
+
+  logger.debug(
+    `Seeking to new start position for fd ${fd.toString()} (${from.toString()} -> ${to.toString()})`,
+  );
+
+  const responsePromise = fdToResponsePromiseMap.get(fd);
+
+  // Drain without blocking. We don't want a slow or large stream to delay the reconnect.
+  void responsePromise?.then(({ body }) => body.dump());
+
+  fdToResponsePromiseMap.delete(fd);
+  fdToCurrentStreamPositionMap.delete(fd);
+}

--- a/apps/riven/lib/vfs/utilities/seek.ts
+++ b/apps/riven/lib/vfs/utilities/seek.ts
@@ -14,13 +14,14 @@ import { getVfsOperationContext } from "./vfs-operation-context.ts";
  * @param to The new stream position
  */
 export function seek(from: number, to: number) {
-  const { fd } = getVfsOperationContext("read");
+  const {
+    fd,
+    context: { responsePromise },
+  } = getVfsOperationContext("read");
 
   logger.debug(
     `Seeking to new start position for fd ${fd.toString()} (${from.toString()} -> ${to.toString()})`,
   );
-
-  const responsePromise = fdToResponsePromiseMap.get(fd);
 
   // Drain without blocking. We don't want a slow or large stream to delay the reconnect.
   void responsePromise?.then(({ body }) => body.dump());

--- a/apps/riven/lib/vfs/utilities/vfs-operation-context.ts
+++ b/apps/riven/lib/vfs/utilities/vfs-operation-context.ts
@@ -2,7 +2,9 @@ import assert from "node:assert";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { Buffer } from "node:buffer";
 
+import type { FileHandleMetadata } from "./file-handle-map.ts";
 import type { Promisable } from "type-fest";
+import type { Dispatcher } from "undici";
 
 export type VfsOperationContext = (
   | {
@@ -19,6 +21,12 @@ export type VfsOperationContext = (
       position: number;
       length: number;
       buffer: Buffer;
+      context: {
+        fileHandleMetadata: FileHandleMetadata;
+        previousReadPosition: number | undefined;
+        currentStreamPosition: number | undefined;
+        responsePromise: Promise<Dispatcher.ResponseData> | undefined;
+      };
     }
   | {
       operationName: "getattr" | "readdir";


### PR DESCRIPTION
### Bug Description
When seeking, performBodyRead was reusing the existing HTTP stream even when it was positioned at the wrong byte offset. The stream would then read data from the old position, cache it under the chunk key for the new position, and deliver those wrong bytes to Plex.

### Main Issue This Caused
Depending on the client, long seeks appeared to cause either indefinite buffering (#106) or audio/visual desync + artifacts

### Fix
Before reusing the stream, `performBodyRead` now checks whether the stream's tracked byte offset matches the start of the chunk being requested. If it doesn't (which is true after any seek landing on a different chunk boundary), the misaligned stream is discarded, and a new request is opened from the correct position. The old stream is drained in the background, so the connection is released cleanly.

Fixes #106 
