### PR TITLE
fix(core): process media request updates

### DIFF
--- a/apps/riven/lib/state-machines/main-runner/index.ts
+++ b/apps/riven/lib/state-machines/main-runner/index.ts
@@ -536,6 +536,10 @@ export const mainRunnerMachine = setup({
                   level: "silly",
                 }),
               },
+              {
+                type: "processItemRequest",
+                params: ({ event: { item } }) => ({ item }),
+              },
             ],
           },
 


### PR DESCRIPTION
### Bug Description
When an existing item request was updated (e.g. a new season added to a show), the state machine received the `update.success` event but took no action, so the updated request was never processed.

### Main Issue This Caused
Request updates were silently ignored. Newly added seasons would never be scraped or downloaded unless Riven was restarted while the show happens to be in a retryable state.

### Fix
The `riven.item-request.update.success` handler now enqueues `processItemRequest`, mirroring the behaviour of `create.success`. Because `processMediaItem` operates on the show as a whole, this also incidentally sweeps up any other requested seasons that were previously pending but unprocessed.

**Note:** Shows with previously ignored seasons will not be retroactively picked up by this fix. Processing will only be triggered once another request is made for the same show.

Fixes #201 