### PR TITLE
fix(riven): tolerate missing log context in sentry formatter

### DIFF
--- a/apps/riven/lib/utilities/logger/formatters/sentry-meta.format.spec.ts
+++ b/apps/riven/lib/utilities/logger/formatters/sentry-meta.format.spec.ts
@@ -1,0 +1,39 @@
+import { expect, it } from "vitest";
+
+import { withLogContext } from "../log-context.ts";
+import { sentryMetaFormat } from "./sentry-meta.format.ts";
+
+import type { SessionID } from "../session-id.ts";
+import type { TransformableInfo } from "logform";
+
+it("does not throw without an active log context", () => {
+  const result = sentryMetaFormat().transform({
+    message: "startup log",
+  } as TransformableInfo);
+
+  expect(result).toMatchObject({
+    message: "startup log",
+  });
+});
+
+it("adds active log context metadata", () => {
+  const sessionId = "00000000-0000-4000-8000-000000000000" as SessionID;
+
+  withLogContext(
+    {
+      "riven.log.source": "test",
+      "riven.session.id": sessionId,
+    },
+    () => {
+      const result = sentryMetaFormat().transform({
+        message: "contextual log",
+      } as TransformableInfo);
+
+      expect(result).toMatchObject({
+        message: "contextual log",
+        "riven.log.source": "test",
+        "riven.session.id": sessionId,
+      });
+    },
+  );
+});

--- a/apps/riven/lib/utilities/logger/formatters/sentry-meta.format.ts
+++ b/apps/riven/lib/utilities/logger/formatters/sentry-meta.format.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/node";
 import { format } from "winston";
 
-import { getOptionalLogContext } from "../log-context.ts";
+import { getLogContext } from "../log-context.ts";
 
 export const sentryMetaFormat = format((info) => {
   const activeSpan = Sentry.getActiveSpan();
@@ -15,6 +15,6 @@ export const sentryMetaFormat = format((info) => {
 
   return {
     ...info,
-    ...getOptionalLogContext(),
+    ...getLogContext(),
   };
 });

--- a/apps/riven/lib/utilities/logger/formatters/sentry-meta.format.ts
+++ b/apps/riven/lib/utilities/logger/formatters/sentry-meta.format.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/node";
 import { format } from "winston";
 
-import { getLogContext } from "../log-context.ts";
+import { getOptionalLogContext } from "../log-context.ts";
 
 export const sentryMetaFormat = format((info) => {
   const activeSpan = Sentry.getActiveSpan();
@@ -15,6 +15,6 @@ export const sentryMetaFormat = format((info) => {
 
   return {
     ...info,
-    ...getLogContext(),
+    ...getOptionalLogContext(),
   };
 });

--- a/apps/riven/lib/utilities/logger/log-context.ts
+++ b/apps/riven/lib/utilities/logger/log-context.ts
@@ -47,3 +47,7 @@ export function getLogContext(): LogContext {
 
   return context;
 }
+
+export function getOptionalLogContext(): LogContext {
+  return logContext.getStore() ?? {};
+}

--- a/apps/riven/lib/utilities/logger/log-context.ts
+++ b/apps/riven/lib/utilities/logger/log-context.ts
@@ -39,15 +39,5 @@ export function withLogContext<T>(
 }
 
 export function getLogContext(): LogContext {
-  const context = logContext.getStore();
-
-  if (!context) {
-    throw new Error("No log context available");
-  }
-
-  return context;
-}
-
-export function getOptionalLogContext(): LogContext {
   return logContext.getStore() ?? {};
 }


### PR DESCRIPTION
## Summary

Fixes #232.

The Sentry/Winston formatter currently calls `getLogContext()` for every log record. That function throws if no `AsyncLocalStorage` context exists, but formatting can happen during startup or other process-level paths before a `withLogContext()` scope is active.

This PR makes `getLogContext()` return an empty context when none is active. The formatter still preserves existing log metadata and adds Riven context when one is active, but missing context no longer crashes the process.

## Tests

- `pnpm exec prettier --check apps/riven/lib/utilities/logger/log-context.ts apps/riven/lib/utilities/logger/formatters/sentry-meta.format.ts apps/riven/lib/utilities/logger/formatters/sentry-meta.format.spec.ts`
- `pnpm exec vitest run lib/utilities/logger/formatters/sentry-meta.format.spec.ts --config /var/folders/yc/d4200bsd5yvfxlqwv19w5z5m0000gn/T/opencode/riven-vitest-no-setup.config.ts`
- `pnpm --filter @repo/riven codegen:gql-schema`
- `pnpm --filter @repo/riven codegen:gql`
- `pnpm --filter @repo/riven check-types`
- `pnpm --filter @repo/riven lint -- lib/utilities/logger/log-context.ts lib/utilities/logger/formatters/sentry-meta.format.ts lib/utilities/logger/formatters/sentry-meta.format.spec.ts`

Note: a normal `pnpm --filter @repo/riven test -- lib/utilities/logger/formatters/sentry-meta.format.spec.ts` loads the app-wide Vitest setup and failed locally because `@zkochan/fuse-native` could not build on macOS arm64 / Node 26 after node-gyp failed to fetch Node headers due local CA validation. The formatter spec itself passes with setup disabled, and type-check/lint pass after generating the required GraphQL artifacts. GitHub Actions runs the full project checks on Linux / Node 24.
