### PR TITLE
fix(core): omit stack traces for expected errors in console logs

### DIFF
--- a/apps/riven/lib/riven-settings.schema.ts
+++ b/apps/riven/lib/riven-settings.schema.ts
@@ -105,7 +105,9 @@ export const RivenSettings = z.object({
   logShowStackTraces: z
     .stringbool()
     .default(true)
-    .describe("Whether to show detailed stack traces when logging errors")
+    .describe(
+      "Whether to show detailed stack traces when unexpected errors occur.",
+    )
     .meta({ "wiki.section": "logging" }),
   gqlHost: z
     .string()

--- a/apps/riven/lib/utilities/logger/formatters/console.format.spec.ts
+++ b/apps/riven/lib/utilities/logger/formatters/console.format.spec.ts
@@ -1,0 +1,61 @@
+import { UnrecoverableError } from "bullmq";
+import { expect, it } from "vitest";
+
+import { consoleFormat } from "./console.format.ts";
+
+import type { TransformableInfo } from "logform";
+
+function render(info: Partial<TransformableInfo>) {
+  const formatted = consoleFormat.transform({
+    "@timestamp": "2026-07-23T23:44:01.000Z",
+    "ecs.version": "8.10.0",
+    "log.level": "error",
+    level: "error",
+    ...info,
+  } as TransformableInfo);
+
+  expect.assert(typeof formatted === "object");
+
+  return formatted[Symbol.for("message")] as string;
+}
+
+it("omits the stack trace for expected errors", () => {
+  expect.assertions(2);
+
+  const error = new UnrecoverableError(
+    "Failed to download Big Buck Bunny: No valid torrent found after trying all downloaders",
+  );
+
+  const output = render({
+    message: "download-item failed:",
+    error: {
+      name: error.name,
+      type: error.name,
+      message: error.message,
+      stack_trace: error.stack ?? "",
+    },
+  });
+
+  expect(output).toContain(
+    "download-item failed: Failed to download Big Buck Bunny: No valid torrent found after trying all downloaders",
+  );
+  expect(output).not.toContain("    at ");
+});
+
+it("keeps the stack trace for unexpected errors", () => {
+  expect.assertions(1);
+
+  const error = new TypeError("Cannot read properties of undefined");
+
+  const output = render({
+    message: "download-item failed:",
+    error: {
+      name: error.name,
+      type: error.name,
+      message: error.message,
+      stack_trace: error.stack ?? "",
+    },
+  });
+
+  expect(output).toContain("    at ");
+});

--- a/apps/riven/lib/utilities/logger/formatters/console.format.spec.ts
+++ b/apps/riven/lib/utilities/logger/formatters/console.format.spec.ts
@@ -16,7 +16,11 @@ function render(info: Partial<TransformableInfo>) {
 
   expect.assert(typeof formatted === "object");
 
-  return formatted[Symbol.for("message")] as string;
+  const message = formatted[Symbol.for("message")];
+
+  expect.assert(typeof message === "string");
+
+  return message;
 }
 
 it("omits the stack trace for expected errors", () => {
@@ -39,6 +43,7 @@ it("omits the stack trace for expected errors", () => {
   expect(output).toContain(
     "download-item failed: Failed to download Big Buck Bunny: No valid torrent found after trying all downloaders",
   );
+
   expect(output).not.toContain("    at ");
 });
 

--- a/apps/riven/lib/utilities/logger/formatters/console.format.ts
+++ b/apps/riven/lib/utilities/logger/formatters/console.format.ts
@@ -9,24 +9,46 @@ import { ErrorSplat } from "../schemas/error-splat.schema.ts";
 
 import type { TransformableInfo } from "logform";
 
-function getErrorOutput(error: Error | TransformableInfo["error"] | null) {
+/** An error after `ecsFormat` has serialised it onto the log entry. */
+type LoggedError = NonNullable<TransformableInfo["error"]>;
+
+/**
+ * Errors we throw deliberately to signal an expected, terminal outcome (e.g. a
+ * media item that cannot be downloaded). The message says everything useful, so
+ * their stack traces are noise in the console/file logs — the full trace is
+ * still written to the ECS logs.
+ *
+ */
+const EXPECTED_ERROR_NAMES = new Set([
+  "FatalValidationError",
+  "UnrecoverableError",
+]);
+
+function isExpectedError(error: Error | LoggedError) {
+  return EXPECTED_ERROR_NAMES.has(
+    error instanceof Error ? error.name : (error.name ?? error.type),
+  );
+}
+
+function getErrorOutput(error: Error | LoggedError | null) {
   if (!error) {
     return;
   }
 
   const { logShowStackTraces } = settings;
+  const showStackTrace = logShowStackTraces && !isExpectedError(error);
 
   if (error instanceof ZodError) {
     // If we have a validation error, prettify the output if stack traces are disabled
-    return logShowStackTraces ? error.stack : z.prettifyError(error);
+    return showStackTrace ? error.stack : z.prettifyError(error);
   }
 
   if (error instanceof Error) {
-    return logShowStackTraces ? error.stack : error.message;
+    return showStackTrace ? error.stack : error.message;
   }
 
   // For regular errors, always show the raw error output if stack traces are enabled, else show the message
-  return logShowStackTraces ? error.stack_trace : error.message;
+  return showStackTrace ? error.stack_trace : error.message;
 }
 
 export const consoleFormat = format.printf(({ level, message, ...meta }) => {

--- a/apps/riven/lib/utilities/logger/formatters/console.format.ts
+++ b/apps/riven/lib/utilities/logger/formatters/console.format.ts
@@ -1,3 +1,6 @@
+import { FatalValidationError } from "@repo/util-plugin-sdk/errors/fatal-validation-error";
+
+import { UnrecoverableError } from "bullmq";
 import chalk from "chalk";
 import { DateTime } from "luxon";
 import { SPLAT } from "triple-beam";
@@ -19,8 +22,8 @@ type LoggedError = NonNullable<TransformableInfo["error"]>;
  * still written to the ECS logs.
  */
 const EXPECTED_ERROR_NAMES = new Set([
-  "FatalValidationError",
-  "UnrecoverableError",
+  FatalValidationError.name,
+  UnrecoverableError.name,
 ]);
 
 function isUnexpectedError(error: Error | LoggedError) {

--- a/apps/riven/lib/utilities/logger/formatters/console.format.ts
+++ b/apps/riven/lib/utilities/logger/formatters/console.format.ts
@@ -17,15 +17,14 @@ type LoggedError = NonNullable<TransformableInfo["error"]>;
  * media item that cannot be downloaded). The message says everything useful, so
  * their stack traces are noise in the console/file logs — the full trace is
  * still written to the ECS logs.
- *
  */
 const EXPECTED_ERROR_NAMES = new Set([
   "FatalValidationError",
   "UnrecoverableError",
 ]);
 
-function isExpectedError(error: Error | LoggedError) {
-  return EXPECTED_ERROR_NAMES.has(
+function isUnexpectedError(error: Error | LoggedError) {
+  return !EXPECTED_ERROR_NAMES.has(
     error instanceof Error ? error.name : (error.name ?? error.type),
   );
 }
@@ -36,7 +35,7 @@ function getErrorOutput(error: Error | LoggedError | null) {
   }
 
   const { logShowStackTraces } = settings;
-  const showStackTrace = logShowStackTraces && !isExpectedError(error);
+  const showStackTrace = logShowStackTraces && isUnexpectedError(error);
 
   if (error instanceof ZodError) {
     // If we have a validation error, prettify the output if stack traces are disabled


### PR DESCRIPTION
`UnrecoverableError` and `FatalValidationError` are thrown deliberately to signal an expected, terminal outcome (e.g. a media item that has no valid torrent). 


```
// current
error: download-item failed: UnrecoverableError: Failed to download The Great Waldo Pepper: No valid torrent found after trying all downloaders
        at file:///app/dist/.../download-item.processor.js:19:15
        at process.processTicksAndRejections (node:internal/...)
        at async file:///app/node_modules/.../zod/v4/core/schemas.js
        ... 3 more frames

// ideal
error: download-item failed: Failed to download Big Buck Bunny: No valid torrent found after trying all downloaders
```

Suppress the trace for these two error types regardless of `logShowStackTraces`, so they render as a single red line. 

Unexpected errors keep their full trace, and the complete `stack_trace` is still written to the ECS logs for debugging. The `logShowStackTraces` description is updated to document the carve-out.