### PR TITLE
fix(repo): coerce numeric env-configured settings from strings

### DIFF
--- a/apps/riven/lib/riven-settings.schema.ts
+++ b/apps/riven/lib/riven-settings.schema.ts
@@ -123,7 +123,8 @@ export const RivenSettings = z.object({
     .default(false)
     .describe("Only scrape dubbed anime.")
     .meta({ "wiki.section": "scraping" }),
-  maximumScrapeAttempts: z
+  maximumScrapeAttempts: z.coerce
+    .number()
     .int()
     .nonnegative()
     .default(Number.MAX_SAFE_INTEGER)
@@ -131,13 +132,15 @@ export const RivenSettings = z.object({
       "The maximum number of scrape attempts before giving up on an item.",
     )
     .meta({ "wiki.section": "scraping" }),
-  minimumAverageBitrateMovies: z
+  minimumAverageBitrateMovies: z.coerce
+    .number()
     .int()
     .positive()
     .optional()
     .describe("The minimum average bitrate for movies.")
     .meta({ "wiki.section": "scraping" }),
-  minimumAverageBitrateEpisodes: z
+  minimumAverageBitrateEpisodes: z.coerce
+    .number()
     .int()
     .positive()
     .optional()
@@ -150,7 +153,8 @@ export const RivenSettings = z.object({
       "If true, Riven will prefer to download season packs over show packs.",
     )
     .meta({ "wiki.section": "scraping" }),
-  scheduleOffsetMinutes: z
+  scheduleOffsetMinutes: z.coerce
+    .number()
     .int()
     .nonnegative()
     .default(30)
@@ -173,7 +177,8 @@ export const RivenSettings = z.object({
     `,
     )
     .meta({ "wiki.section": "scraping" }),
-  unknownAirDateOffsetDays: z
+  unknownAirDateOffsetDays: z.coerce
+    .number()
     .int()
     .nonnegative()
     .default(7)

--- a/packages/plugin-listrr/lib/listrr-settings.schema.ts
+++ b/packages/plugin-listrr/lib/listrr-settings.schema.ts
@@ -14,7 +14,8 @@ export const ListrrSettings = z.object({
   showLists: json(z.array(z.string().min(1)))
     .default([])
     .describe("List of Listrr show lists to request"),
-  updateIntervalSeconds: z
+  updateIntervalSeconds: z.coerce
+    .number()
     .int()
     .nonnegative()
     .default(Duration.fromObject({ days: 1 }).as("seconds"))

--- a/packages/plugin-mdblist/lib/mdblist-settings.schema.ts
+++ b/packages/plugin-mdblist/lib/mdblist-settings.schema.ts
@@ -11,7 +11,8 @@ export const MdbListSettings = z.object({
   lists: json(z.array(z.string().min(1)))
     .default([])
     .describe("List of MdbList lists to request"),
-  updateIntervalSeconds: z
+  updateIntervalSeconds: z.coerce
+    .number()
     .int()
     .nonnegative()
     .default(Duration.fromObject({ days: 1 }).as("seconds"))


### PR DESCRIPTION
Environment variables always arrive as string, but several numeric settings were declared with a plain `z.int()`, which rejects string input with "expected number, received string".

I switched the affected env-populated numeric fields to `z.coerce.number().int()`, matching the existing convention already used by `gqlPort`:

- plugin-listrr / plugin-mdblist: `updateIntervalSeconds`
- riven core settings: `maximumScrapeAttempts`, `minimumAverageBitrateMovies`, `minimumAverageBitrateEpisodes`, `scheduleOffsetMinutes`, `unknownAirDateOffsetDays`

Validation is unchanged: non-numeric, negative, and non-integer values are still rejected, `.optional()` fields stay undefined when unset, and defaults still apply. Fields already wrapped in the `json()` codec (seerr's `updateIntervalSeconds`, `scrapeCooldownHours`, `shutdownTimeoutSeconds`) already handled string input and are left alone.