### PR TITLE
fix(stremthru): set ep=1 for season-level torznab scrapes

### DIFF
--- a/packages/plugin-stremthru/lib/datasource/stremthru-torznab.datasource.ts
+++ b/packages/plugin-stremthru/lib/datasource/stremthru-torznab.datasource.ts
@@ -57,6 +57,7 @@ export class StremThruTorznabAPI extends BaseDataSource<StremThruSettings> {
 
       if (item instanceof Season) {
         params.set("season", item.number.toString());
+        params.set("ep", "1");
       }
 
       if (item instanceof Episode) {


### PR DESCRIPTION
**Issue**
Stremthru season level queries were silently failing with 0 results, despite cached results existing in it's DDM cache. 

**Cause**
* StremThru's ListHashesByStremId mishandles 2-part strem ids like `(tt123:5):`. 
* it binds the bare imdb id to a LIKE with no wildcard, so the query can only match show-level sid rows and never tt123:S:E rows, and it skips the imdb_torrent UNION that surfaces season packs. 
* The endpoint accepts the query and returns an empty result rather than an error, so most of season-level scrapes silently returned zero torrents.

**Fix**
* Query imdbid-only for Season items and let parse-scrape-results filter by parsed season/episodes, as the movie/show path already does successfully. 
* That filter already rejects wrong-season torrents and requires episode-level torrents to cover the full season, so only real season packs survive ranking.